### PR TITLE
feat: write run_local.sh (issue 1.4)

### DIFF
--- a/run_local.sh
+++ b/run_local.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Load environment variables from .env if it exists
+if [ -f .env ]; then
+  set -a
+  source .env
+  set +a
+fi
+
+cd server
+uvicorn main:app --host 0.0.0.0 --port 8000 --reload


### PR DESCRIPTION
## Summary
- Sources `.env` before starting (using `set -a` / `source` / `set +a` pattern)
- Starts uvicorn on port 8000 with `--reload` for local dev
- `client/` is served as FastAPI `StaticFiles` — no separate frontend server needed

## Test plan
- [ ] `./run_local.sh` starts without errors (once `server/main.py` is implemented in issue 2.x)
- [ ] Env vars from `.env` are visible to the server process

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)