### PR TITLE
feat: mount client/ as static files in main.py

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -1,0 +1,12 @@
+import os
+
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+
+app = FastAPI()
+
+# API routes are registered here (future issues)
+
+# Static files — mounted last so API routes take priority
+_client_dir = os.path.join(os.path.dirname(__file__), "..", "client")
+app.mount("/", StaticFiles(directory=_client_dir, html=True), name="static")


### PR DESCRIPTION
## Summary
- Adds FastAPI `StaticFiles` mount serving `client/` at `/`
- `html=True` enables `index.html` to be served at the root path
- Mount is registered after API routes so future API endpoints take priority

## Test plan
- [x] Run `./run_local.sh` and verify `http://localhost:8000/` returns `index.html`
- [x] Verify `http://localhost:8000/app.js` and `http://localhost:8000/style.css` are accessible
- [x] Verify `/docs` and `/openapi.json` still work (API routes take priority)

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)