### PR TITLE
feat: define Melody ADK agent in agent.py (issue #11)

### DIFF
--- a/server/melody_agent/agent.py
+++ b/server/melody_agent/agent.py
@@ -1,0 +1,36 @@
+"""Melody ADK agent definition."""
+
+from google.adk.agents import Agent
+from google.adk.tools import google_search
+from google.genai import types
+
+from melody_agent.prompts import build_prompt
+from melody_agent.tools import emit_job_card
+
+_VOICE_CONFIG = types.GenerateContentConfig(
+    speech_config=types.SpeechConfig(
+        voice_config=types.VoiceConfig(
+            prebuilt_voice_config=types.PrebuiltVoiceConfig(voice_name="Aoede")
+        )
+    )
+)
+
+
+def create_agent(resume_data: dict) -> Agent:
+    """Instantiate Melody with resume data injected into the system prompt.
+
+    Called once per WebSocket session so each user gets a prompt personalised
+    to their own resume.
+    """
+    return Agent(
+        name="melody",
+        model="gemini-2.5-flash-native-audio-latest",
+        instruction=build_prompt(resume_data),
+        tools=[google_search, emit_job_card],
+        generate_content_config=_VOICE_CONFIG,
+    )
+
+
+# Module-level instance required for ADK app discovery (`adk web` / `adk run`).
+# The WebSocket handler always calls create_agent(resume_data) instead.
+root_agent = create_agent({})

--- a/server/melody_agent/tools.py
+++ b/server/melody_agent/tools.py
@@ -1,0 +1,19 @@
+"""Melody custom tools — stub until Issues 4.1 and 4.2 are implemented."""
+
+from google.adk.tools import ToolContext
+
+
+def emit_job_card(
+    tool_context: ToolContext,
+    title: str,
+    company: str,
+    reasons: list[str],
+    url: str,
+    salary: str = "Not listed",
+) -> dict:
+    """Emit a job card to the client (stub — Issue 4.1).
+
+    Appends a card dict to tool_context.state['pending_cards'] so the
+    WebSocket handler can forward it to the browser as a JSON event.
+    """
+    raise NotImplementedError("emit_job_card is not yet implemented (Issue 4.1)")


### PR DESCRIPTION
## Summary
- `create_agent(resume_data)` factory builds `Agent` with `build_prompt()` injected — one per WebSocket session for personalised prompts
- Model: `gemini-2.5-flash-native-audio-latest`
- Voice: Aoede via `SpeechConfig` / `PrebuiltVoiceConfig` on `generate_content_config`
- Tools: `google_search` + `emit_job_card`; no sub-agents
- `root_agent = create_agent({})` at module level for ADK app discovery
- Adds `emit_job_card` stub to `tools.py` so imports resolve (full impl tracked in issue #12)

Closes #11

## Test plan
- [x] `from melody_agent.agent import root_agent, create_agent` — no import errors
- [x] `root_agent.name == "melody"`
- [x] `create_agent(sample_resume).name == "melody"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)