### PR TITLE
feat: implement emit_job_card tool

### DIFF
--- a/server/melody_agent/tools.py
+++ b/server/melody_agent/tools.py
@@ -1,4 +1,4 @@
-"""Melody custom tools — stub until Issues 4.1 and 4.2 are implemented."""
+"""Melody custom tools."""
 
 from google.adk.tools import ToolContext
 
@@ -11,9 +11,21 @@ def emit_job_card(
     url: str,
     salary: str = "Not listed",
 ) -> dict:
-    """Emit a job card to the client (stub — Issue 4.1).
+    """Emit a job card to the client.
 
     Appends a card dict to tool_context.state['pending_cards'] so the
     WebSocket handler can forward it to the browser as a JSON event.
     """
-    raise NotImplementedError("emit_job_card is not yet implemented (Issue 4.1)")
+    card = {
+        "title": title,
+        "company": company,
+        "reasons": reasons[:3],
+        "url": url,
+        "salary": salary,
+    }
+
+    if "pending_cards" not in tool_context.state:
+        tool_context.state["pending_cards"] = []
+    tool_context.state["pending_cards"].append(card)
+
+    return {"status": "emitted", "card": card}


### PR DESCRIPTION
## Summary
- Implements `emit_job_card` in `server/melody_agent/tools.py` (closes #12)
- Appends a card dict to `tool_context.state["pending_cards"]`, initializing the list if absent
- Caps `reasons` at 3 entries as specified
- Returns `{"status": "emitted", "card": card}`

## Test plan
- [ ] Start Melody agent via `adk web` and trigger a job search conversation
- [ ] Verify `pending_cards` in session state is populated after the agent calls `emit_job_card`
- [ ] Verify the returned dict has `status: "emitted"` and the correct card fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)