### PR TITLE
feat: implement build_job_query tool

### DIFF
--- a/server/melody_agent/agent.py
+++ b/server/melody_agent/agent.py
@@ -5,7 +5,7 @@ from google.adk.tools import google_search
 from google.genai import types
 
 from melody_agent.prompts import build_prompt
-from melody_agent.tools import emit_job_card
+from melody_agent.tools import build_job_query, emit_job_card
 
 _VOICE_CONFIG = types.GenerateContentConfig(
     speech_config=types.SpeechConfig(
@@ -26,7 +26,7 @@ def create_agent(resume_data: dict) -> Agent:
         name="melody",
         model="gemini-2.5-flash-native-audio-latest",
         instruction=build_prompt(resume_data),
-        tools=[google_search, emit_job_card],
+        tools=[google_search, build_job_query, emit_job_card],
         generate_content_config=_VOICE_CONFIG,
     )
 

--- a/server/melody_agent/tools.py
+++ b/server/melody_agent/tools.py
@@ -3,6 +3,42 @@
 from google.adk.tools import ToolContext
 
 
+def build_job_query(state: dict) -> str:
+    """Build a Google search query for job postings from conversation state.
+
+    Args:
+        state: Accumulated session state with keys:
+            - role_type (str): e.g. "senior product manager"
+            - location (str): e.g. "remote" or "New York"
+            - priorities (list[str]): must-haves / nice-to-haves from the conversation
+            - anti_priorities (list[str]): dealbreakers (excluded via '-' prefix)
+
+    Returns:
+        A query string ready to pass to google_search.
+        Example: "senior product manager remote SaaS fintech job posting 2026"
+    """
+    parts = []
+
+    if state.get("role_type"):
+        parts.append(state["role_type"])
+
+    if state.get("location"):
+        parts.append(state["location"])
+
+    for priority in state.get("priorities", [])[:3]:
+        parts.append(priority)
+
+    parts.append("job posting 2026")
+
+    exclusions = " ".join(
+        f"-{term}" for term in state.get("anti_priorities", [])[:2]
+    )
+    if exclusions:
+        parts.append(exclusions)
+
+    return " ".join(parts)
+
+
 def emit_job_card(
     tool_context: ToolContext,
     title: str,


### PR DESCRIPTION
## Summary
- Implements `build_job_query(state: dict) -> str` in `tools.py` (closes #13)
- Assembles a search query from `role_type`, `location`, `priorities` (up to 3), and `anti_priorities` (up to 2, prefixed with `-`)
- Registers it as an agent tool in `agent.py`
- Empty state gracefully returns `"job posting 2026"`

## Example outputs
- `"senior product manager remote SaaS fintech job posting 2026"`
- `"software engineer New York startup AI job posting 2026 -consulting -defense"`

## Test plan
- [ ] Smoke-tested locally with several state shapes — output matches spec
- [ ] Full integration test when WebSocket handler (issue #14) is implemented and a live session can be run

🤖 Generated with [Claude Code](https://claude.com/claude-code)