### PR TITLE
feat: implement WebSocket endpoint /ws/{session_id}

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -1,10 +1,17 @@
+import asyncio
+import json
 import os
 import uuid
 from typing import Any
 
-from fastapi import FastAPI, File, HTTPException, UploadFile
+from fastapi import FastAPI, File, HTTPException, UploadFile, WebSocket, WebSocketDisconnect
 from fastapi.staticfiles import StaticFiles
+from google.adk.agents.live_request_queue import LiveRequestQueue
+from google.adk.agents.run_config import RunConfig, StreamingMode
+from google.adk.runners import InMemoryRunner
+from google.genai import types as genai_types
 
+from melody_agent.agent import create_agent
 from melody_agent.resume_parser import parse_resume
 
 app = FastAPI()
@@ -34,6 +41,86 @@ async def upload_resume(file: UploadFile = File(...)):
     _sessions[session_id] = parsed
 
     return {"session_id": session_id, **parsed}
+
+
+@app.websocket("/ws/{session_id}")
+async def websocket_session(websocket: WebSocket, session_id: str):
+    """Live voice session for a given resume session.
+
+    Binary frames in:  PCM 16-bit mono 16 kHz (from browser audio worklet)
+    Binary frames out: PCM 16-bit mono 24 kHz (Gemini Live audio)
+    Text frames out:   JSON {"type": "job_card", ...} after each agent turn
+    """
+    resume_data = _sessions.get(session_id)
+    if resume_data is None:
+        await websocket.close(code=4404)
+        return
+
+    await websocket.accept()
+
+    agent = create_agent(resume_data)
+    runner = InMemoryRunner(agent=agent, app_name="melody")
+
+    adk_session = await runner.session_service.create_session(
+        app_name=runner.app_name,
+        user_id="user",
+    )
+    adk_session_id = adk_session.id
+
+    live_queue = LiveRequestQueue()
+    run_config = RunConfig(streaming_mode=StreamingMode.BIDI)
+
+    async def receive_audio():
+        """Browser → LiveRequestQueue: forward raw PCM blobs."""
+        try:
+            while True:
+                data = await websocket.receive_bytes()
+                live_queue.send_realtime(
+                    genai_types.Blob(data=data, mime_type="audio/pcm;rate=16000")
+                )
+        except WebSocketDisconnect:
+            live_queue.close()
+
+    async def send_events():
+        """ADK events → browser: audio chunks and job cards."""
+        try:
+            async for event in runner.run_live(
+                user_id="user",
+                session_id=adk_session_id,
+                live_request_queue=live_queue,
+                run_config=run_config,
+            ):
+                # Forward agent audio as binary frames
+                if event.content and event.content.parts:
+                    for part in event.content.parts:
+                        if part.inline_data and part.inline_data.data:
+                            await websocket.send_bytes(part.inline_data.data)
+
+                # After each turn flush pending job cards from session state
+                if event.turn_complete:
+                    real_session = runner.session_service.sessions[
+                        runner.app_name
+                    ]["user"][adk_session_id]
+                    cards = real_session.state.pop("pending_cards", [])
+                    for card in cards:
+                        await websocket.send_text(
+                            json.dumps({"type": "job_card", **card})
+                        )
+        except WebSocketDisconnect:
+            pass
+
+    recv_task = asyncio.create_task(receive_audio())
+    send_task = asyncio.create_task(send_events())
+
+    done, pending = await asyncio.wait(
+        [recv_task, send_task], return_when=asyncio.FIRST_COMPLETED
+    )
+    for task in pending:
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, WebSocketDisconnect):
+            pass
 
 
 # Static files — mounted last so API routes take priority


### PR DESCRIPTION
## Summary
- Adds `GET /ws/{session_id}` WebSocket endpoint to `main.py` (closes #14)
- Looks up `resume_data` from the upload session store; closes with code 4404 if not found
- Creates a per-connection `InMemoryRunner` + ADK session + `LiveRequestQueue`
- Runs two concurrent asyncio tasks:
  - **receive**: browser binary frames (PCM 16kHz) → `live_queue.send_realtime()`
  - **send**: ADK events → binary audio frames (PCM 24kHz) to browser; JSON `{"type": "job_card", ...}` text frames after each `turn_complete`
- Clears `pending_cards` from session state after forwarding
- Cancels the remaining task cleanly when either side disconnects

## Key ADK details
- `RunConfig(streaming_mode=StreamingMode.BIDI)` for live audio
- Session state is read directly from `runner.session_service.sessions` (InMemorySessionService internal dict) to allow mutation for clearing `pending_cards`; acceptable for an in-memory dev/hackathon runner

## Test plan
- [ ] Full integration test requires frontend audio worklets (issues #15–#16) — same situation as #12/#13
- [ ] Can smoke-test the WebSocket upgrade path with a simple ws client once a valid session_id is obtained from `/upload`

🤖 Generated with [Claude Code](https://claude.com/claude-code)