### PR TITLE
feat: implement audio-player-worklet.js (issue #16)

### DIFF
--- a/client/audio-player-worklet.js
+++ b/client/audio-player-worklet.js
@@ -1,0 +1,117 @@
+/**
+ * audio-player-worklet.js
+ *
+ * AudioWorkletProcessor that buffers incoming Int16 PCM chunks received from
+ * the WebSocket (via the main thread), resamples from the input rate (default
+ * 24 kHz — Gemini Live output) to the AudioContext sample rate, and writes
+ * them to the output channel.
+ *
+ * Handles buffer underrun by outputting silence (zeros) — no clicks or pops.
+ *
+ * Constructor processorOptions:
+ *   inputSampleRate  {number}  PCM rate of incoming data (default: 24000)
+ *   bufferSeconds    {number}  Ring buffer size in seconds (default: 4)
+ *
+ * Messages FROM main thread:
+ *   ArrayBuffer  — Int16 PCM samples to enqueue
+ *   'flush'      — clear the buffer (e.g. on barge-in / session reset)
+ *
+ * Messages TO main thread:
+ *   { type: 'underrun' } — emitted once per underrun event (for UI feedback)
+ */
+class AudioPlayerProcessor extends AudioWorkletProcessor {
+  constructor(options) {
+    super();
+
+    const opts           = options.processorOptions ?? {};
+    this._inputRate      = opts.inputSampleRate ?? 24000;
+    const bufSeconds     = opts.bufferSeconds   ?? 4;
+
+    // Ring buffer stores Float32 samples at the input rate
+    this._capacity       = Math.ceil(this._inputRate * bufSeconds);
+    this._ring           = new Float32Array(this._capacity);
+    this._writePos       = 0;
+    this._readPos        = 0;
+    this._size           = 0;
+
+    // Pre-allocate temp buffer for one process() block.
+    // ratio = inputRate / contextRate; if ratio > 1 we need more input samples
+    // than output samples per block.  +2 gives the interpolation tail plus slack.
+    const ratio          = this._inputRate / sampleRate;
+    this._tempSize       = Math.ceil(128 * ratio) + 2;
+    this._temp           = new Float32Array(this._tempSize);
+
+    this._wasUnderrun    = false;
+
+    this.port.onmessage = (e) => {
+      if (e.data instanceof ArrayBuffer) {
+        this._enqueue(new Int16Array(e.data));
+      } else if (e.data === 'flush') {
+        this._writePos = 0;
+        this._readPos  = 0;
+        this._size     = 0;
+      }
+    };
+  }
+
+  /** Convert Int16 samples to Float32 and append to the ring buffer. */
+  _enqueue(samples) {
+    for (let i = 0; i < samples.length; i++) {
+      if (this._size >= this._capacity) {
+        // Overflow: drop oldest sample to make room for fresh audio
+        this._readPos = (this._readPos + 1) % this._capacity;
+        this._size--;
+      }
+      this._ring[this._writePos] = samples[i] / 32768.0;
+      this._writePos = (this._writePos + 1) % this._capacity;
+      this._size++;
+    }
+  }
+
+  process(inputs, outputs) {
+    const channel = outputs[0]?.[0];
+    if (!channel) return true;
+
+    const outLen   = channel.length;                     // 128 frames (render quantum)
+    const ratio    = this._inputRate / sampleRate;       // e.g. 24000/48000 = 0.5
+    const inNeeded = Math.ceil(outLen * ratio) + 1;      // +1 for interpolation tail
+
+    // Pull inNeeded samples from ring buffer; zero-fill on underrun (silence)
+    const available = Math.min(inNeeded, this._size);
+    const underrun  = available < inNeeded;
+
+    for (let i = 0; i < available; i++) {
+      this._temp[i] = this._ring[this._readPos];
+      this._readPos = (this._readPos + 1) % this._capacity;
+    }
+    for (let i = available; i < inNeeded; i++) {
+      this._temp[i] = 0; // silence padding
+    }
+    this._size -= available;
+
+    // Notify main thread on leading edge of each underrun (not every block)
+    if (underrun && !this._wasUnderrun) {
+      this.port.postMessage({ type: 'underrun' });
+    }
+    this._wasUnderrun = underrun;
+
+    // Linear interpolation resample: inputRate → AudioContext sample rate
+    for (let i = 0; i < outLen; i++) {
+      const pos  = i * ratio;
+      const idx  = Math.floor(pos);
+      const frac = pos - idx;
+      const a    = this._temp[idx];
+      const b    = idx + 1 < inNeeded ? this._temp[idx + 1] : a;
+      channel[i] = a + frac * (b - a);
+    }
+
+    // Mono → stereo: copy channel 0 to any additional output channels
+    for (let ch = 1; ch < outputs[0].length; ch++) {
+      outputs[0][ch].set(channel);
+    }
+
+    return true;
+  }
+}
+
+registerProcessor('audio-player-processor', AudioPlayerProcessor);


### PR DESCRIPTION
Closes #16

## Summary
- Implements `AudioPlayerProcessor` (`audio-player-worklet.js`) for real-time playback of 24 kHz PCM audio from Gemini Live via WebSocket
- Ring buffer (4 s at 24 kHz) queues incoming Int16 PCM frames; overflow drops oldest samples to keep audio fresh
- Linear interpolation resamples 24 kHz → AudioContext rate (48 kHz / 44.1 kHz) inside the real-time render thread with no heap allocation
- Buffer underrun outputs silence (zeros) — no clicks or pops; a single `{ type: 'underrun' }` message fires on the leading edge of each starved period for optional UI feedback
- `'flush'` message clears the buffer on barge-in or session reset

## Design notes
- Mirrors the structure of `audio-recorder-worklet.js` (same project pattern)
- `_temp` pre-allocated in constructor to avoid GC pressure in `process()`
- Mono audio auto-copied to additional output channels for stereo contexts
- Registers as `'audio-player-processor'` — connect with `AudioWorkletNode('audio-player-processor')`

## Test plan
- [ ] Load `index.html` in browser; verify no console errors from worklet registration
- [ ] Upload a resume and start a voice session (issue #5.4 wires this up); confirm Melody's audio plays back without clicks
- [ ] Verify underrun silence: pause network delivery briefly; confirm silence (not noise) then resume cleanly
- [ ] Test at both 44100 Hz and 48000 Hz AudioContext rates if possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)