### PR TITLE
feat: implement job card renderer in app.js (issue #18)

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -207,9 +207,43 @@ function stopVoiceSession() {
   meetMelodyBtn.textContent = 'Session ended';
 }
 
-// Stub — replaced by issue #6.1
+// --- Job card renderer ---
+const jobCardsSection = document.getElementById('job-cards');
+let jobCardCount = 0;
+
 function renderJobCard(card) {
-  console.log('job_card received', card);
+  if (jobCardCount >= 3) return;
+  jobCardCount++;
+
+  jobCardsSection.hidden = false;
+
+  const reasonsHTML = (card.reasons || [])
+    .slice(0, 3)
+    .map(r => `<li>${escapeHTML(r)}</li>`)
+    .join('');
+
+  const el = document.createElement('article');
+  el.className = 'job-card';
+  el.innerHTML =
+    `<div class="job-card-header">` +
+      `<h3 class="job-title">${escapeHTML(card.title)}</h3>` +
+      `<span class="job-company">${escapeHTML(card.company)}</span>` +
+    `</div>` +
+    `<ul class="job-reasons">${reasonsHTML}</ul>` +
+    `<div class="job-card-footer">` +
+      `<span class="job-salary">${escapeHTML(card.salary || 'Not listed')}</span>` +
+      `<a class="job-link" href="${escapeHTML(card.url)}" target="_blank" rel="noopener noreferrer">View posting</a>` +
+    `</div>`;
+
+  jobCardsSection.appendChild(el);
+  // Defer class add so CSS transition fires
+  requestAnimationFrame(() => el.classList.add('visible'));
+}
+
+function escapeHTML(str) {
+  const div = document.createElement('div');
+  div.textContent = String(str ?? '');
+  return div.innerHTML;
 }
 
 // --- Helpers ---

--- a/client/index.html
+++ b/client/index.html
@@ -28,6 +28,9 @@
       <p id="resume-summary"></p>
       <button id="meet-melody-btn">Meet Melody</button>
     </section>
+
+    <!-- Job cards revealed during voice session (max 3) -->
+    <section id="job-cards" hidden></section>
   </main>
 
   <script src="app.js"></script>

--- a/client/style.css
+++ b/client/style.css
@@ -125,3 +125,81 @@ button {
   font-size: 0.85rem;
   color: #dc2626;
 }
+
+/* ── Job cards ────────────────────────────────────────────────── */
+#job-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.job-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  /* Fade + slide in from bottom */
+  opacity: 0;
+  transform: translateY(16px);
+  transition: opacity 0.35s ease, transform 0.35s ease;
+}
+
+.job-card.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.job-card-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.job-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1e1b2e;
+}
+
+.job-company {
+  font-size: 0.875rem;
+  color: #6D28D9;
+  font-weight: 500;
+}
+
+.job-reasons {
+  list-style: disc;
+  padding-left: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+  color: #374151;
+  line-height: 1.5;
+}
+
+.job-card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.job-salary {
+  font-size: 0.825rem;
+  color: #6b7280;
+}
+
+.job-link {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #6D28D9;
+  text-decoration: none;
+}
+
+.job-link:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
Closes #18

## Summary
- Replaces the `renderJobCard` stub with a full DOM renderer that fires on `job_card` WebSocket events
- Each card shows: company name, role title, up to 3 reason bullets, salary (or "Not listed"), and a link to the posting
- Max 3 cards total; cards appear sequentially in a new `#job-cards` section added to `index.html`
- Fade + slide-in-from-bottom animation via CSS transition (`.job-card` → `.job-card.visible`)
- `escapeHTML()` helper prevents XSS from untrusted card field values

## Test plan
- [ ] Start a local session via `./run_local.sh`
- [ ] Trigger a job search in the voice session so Melody calls `emit_job_card`
- [ ] Verify cards appear sequentially below the CTA section with the fade/slide animation
- [ ] Confirm a 4th card is not rendered (max 3)
- [ ] Confirm salary shows "Not listed" when the field is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)