### PR TITLE
fix: use bypass_multi_tools_limit=True so google_search works with other tools (issue #41)

### DIFF
--- a/server/melody_agent/agent.py
+++ b/server/melody_agent/agent.py
@@ -1,7 +1,7 @@
 """Melody ADK agent definition."""
 
 from google.adk.agents import Agent
-from google.adk.tools import google_search
+from google.adk.tools.google_search_tool import GoogleSearchTool
 from google.genai import types
 
 from melody_agent.prompts import build_prompt
@@ -17,7 +17,7 @@ def create_agent(resume_data: dict) -> Agent:
         name="melody",
         model="gemini-2.5-flash-native-audio-preview-12-2025",
         instruction=build_prompt(resume_data),
-        tools=[google_search, build_job_query, emit_job_card],
+        tools=[GoogleSearchTool(bypass_multi_tools_limit=True), build_job_query, emit_job_card],
     )
 
 


### PR DESCRIPTION
Fixes #41

## Root cause
`google_search` from ADK is a **model-side built-in grounding tool** — Gemini's API rejects requests that mix a grounding tool with regular function-call tools. ADK has a workaround (`bypass_multi_tools_limit=True`) that transparently wraps `google_search` in a sub-agent, making it compatible. The singleton `google_search` exported from `google.adk.tools` has this flag set to `False` by default, so the workaround never fired — crashing the session the moment Melody tried to search.

## Change
```python
# before
from google.adk.tools import google_search
tools=[google_search, build_job_query, emit_job_card]

# after
from google.adk.tools.google_search_tool import GoogleSearchTool
tools=[GoogleSearchTool(bypass_multi_tools_limit=True), build_job_query, emit_job_card]
```

## Test plan
- [ ] Run `./run_local.sh`, complete the upload + voice session flow
- [ ] Talk to Melody until she triggers the job search phase
- [ ] Confirm session stays alive and Melody returns job results
- [ ] Confirm job cards appear in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)