### PR TITLE
feat: style job cards (issue #19)

### DIFF
--- a/client/style.css
+++ b/client/style.css
@@ -134,12 +134,16 @@ button {
 }
 
 .job-card {
-  border: 1px solid #e5e7eb;
+  background: #ffffff;
+  border-left: 4px solid #6D28D9;
   border-radius: 0.75rem;
   padding: 1.25rem;
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+  max-width: 480px;
+  width: 100%;
+  margin-inline: auto;
   /* Fade + slide in from bottom */
   opacity: 0;
   transform: translateY(16px);
@@ -165,7 +169,7 @@ button {
 
 .job-company {
   font-size: 0.875rem;
-  color: #6D28D9;
+  color: #1e1b2e;
   font-weight: 500;
 }
 
@@ -175,8 +179,8 @@ button {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  font-size: 0.875rem;
-  color: #374151;
+  font-size: 0.8125rem;
+  color: #6b7280;
   line-height: 1.5;
 }
 
@@ -197,9 +201,9 @@ button {
   font-size: 0.85rem;
   font-weight: 600;
   color: #6D28D9;
-  text-decoration: none;
+  text-decoration: underline;
 }
 
 .job-link:hover {
-  text-decoration: underline;
+  color: #5b21b6;
 }


### PR DESCRIPTION
## Summary
- White card background with 4px `#6D28D9` violet left border accent
- Company + title both in dark text (`#1e1b2e`); previously company was violet
- Reasons bullets in gray (`#6b7280`) at 13px — visually smaller and softer
- Salary already gray; job link now always underlined (violet CTA)
- `max-width: 480px` + `margin-inline: auto` ensures card stays centered and mobile-safe

Closes #19

## Test plan
- [ ] Run `adk web` or open `client/index.html` in browser
- [ ] Trigger job cards via voice session and verify: white card, violet left border, dark title/company, gray bullet reasons, gray salary, underlined violet link

🤖 Generated with [Claude Code](https://claude.com/claude-code)