### PR TITLE
feat: deploy.sh + Dockerfile for Cloud Run (issue #20)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY server/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY server/ ./server/
+COPY client/ ./client/
+
+WORKDIR /app/server
+
+CMD exec uvicorn main:app --host 0.0.0.0 --port ${PORT:-8080}

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── Config ───────────────────────────────────────────────────────────────────
+SERVICE_NAME="melody"
+REGION="us-central1"
+
+# ── Env checks ───────────────────────────────────────────────────────────────
+if [ -z "${GOOGLE_CLOUD_PROJECT:-}" ]; then
+  echo "ERROR: GOOGLE_CLOUD_PROJECT is not set." >&2
+  exit 1
+fi
+
+if [ -z "${GOOGLE_API_KEY:-}" ]; then
+  echo "ERROR: GOOGLE_API_KEY is not set." >&2
+  exit 1
+fi
+
+echo "Project : $GOOGLE_CLOUD_PROJECT"
+echo "Service : $SERVICE_NAME"
+echo "Region  : $REGION"
+echo ""
+
+# ── Enable required APIs ─────────────────────────────────────────────────────
+echo "Enabling required GCP APIs..."
+gcloud services enable \
+  run.googleapis.com \
+  cloudbuild.googleapis.com \
+  artifactregistry.googleapis.com \
+  generativelanguage.googleapis.com \
+  --project "$GOOGLE_CLOUD_PROJECT"
+
+# ── Deploy ───────────────────────────────────────────────────────────────────
+echo ""
+echo "Deploying to Cloud Run..."
+gcloud run deploy "$SERVICE_NAME" \
+  --source . \
+  --region "$REGION" \
+  --project "$GOOGLE_CLOUD_PROJECT" \
+  --platform managed \
+  --allow-unauthenticated \
+  --set-env-vars "GOOGLE_API_KEY=${GOOGLE_API_KEY},GOOGLE_GENAI_USE_VERTEXAI=0" \
+  --memory 512Mi \
+  --timeout 3600
+
+# ── Print URL ────────────────────────────────────────────────────────────────
+echo ""
+URL=$(gcloud run services describe "$SERVICE_NAME" \
+  --region "$REGION" \
+  --project "$GOOGLE_CLOUD_PROJECT" \
+  --format "value(status.url)")
+echo "✓ Live at: $URL"


### PR DESCRIPTION
## Summary
- `deploy.sh` — reads `GOOGLE_CLOUD_PROJECT` + `GOOGLE_API_KEY` from env, enables the 4 required GCP APIs, runs `gcloud run deploy --source .`, and prints the live URL
- `Dockerfile` — copies `server/` and `client/` so FastAPI `StaticFiles` can serve the frontend from `../client`; no separate frontend deploy needed

## Key decisions
- `--timeout 3600` keeps long-running WebSocket voice sessions alive (default 300s would kill mid-session)
- `--allow-unauthenticated` makes the public demo URL accessible without IAM setup
- `--memory 512Mi` gives headroom for ADK + audio buffering
- Artifact Registry API is enabled explicitly (required by `--source` builds even though the user never touches it directly)

## Test plan
- [ ] Set `GOOGLE_CLOUD_PROJECT` and `GOOGLE_API_KEY` in env
- [ ] Run `./deploy.sh` — verify APIs enable, build succeeds, URL prints
- [ ] Open the URL in browser — upload a resume, start a voice session, receive job cards
- [ ] Confirm WebSocket stays open for a full session (no 300s timeout kill)

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)