### PR TITLE
fix: raise client-side VAD silence threshold and add speech debounce (#49)

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -148,7 +148,11 @@ async function startVoiceSession(sid) {
   // Recorder: mic → worklet
   const micSource = audioCtx.createMediaStreamSource(stream);
   recorderNode = new AudioWorkletNode(audioCtx, 'audio-recorder-processor', {
-    processorOptions: { targetSampleRate: 16000 },
+    processorOptions: {
+      targetSampleRate:    16000,
+      silenceThreshold:    0.03,  // ~-30 dBFS; rejects background noise while catching speech
+      speechConfirmFrames: 3,     // debounce: require 3 consecutive frames before speech_start
+    },
   });
   micSource.connect(recorderNode);
   recorderNode.connect(audioCtx.destination); // keeps worklet alive; muted by default

--- a/client/audio-recorder-worklet.js
+++ b/client/audio-recorder-worklet.js
@@ -6,24 +6,28 @@
  * for forwarding over WebSocket.
  *
  * Constructor processorOptions:
- *   targetSampleRate  {number}  Target sample rate in Hz (default: 16000)
- *   silenceThreshold  {number}  RMS level below which a frame is "silent" (default: 0.01)
- *   silencePadFrames  {number}  Silent frames to include after speech ends (default: 8)
+ *   targetSampleRate   {number}  Target sample rate in Hz (default: 16000)
+ *   silenceThreshold   {number}  RMS level below which a frame is "silent" (default: 0.03)
+ *   silencePadFrames   {number}  Silent frames to include after speech ends (default: 8)
+ *   speechConfirmFrames {number} Consecutive above-threshold frames required before
+ *                                firing speech_start, to reject short transients (default: 3)
  */
 class AudioRecorderProcessor extends AudioWorkletProcessor {
   constructor(options) {
     super();
 
     const opts = options.processorOptions ?? {};
-    this._targetRate     = opts.targetSampleRate ?? 16000;
-    this._threshold      = opts.silenceThreshold ?? 0.01;
-    this._padFrames      = opts.silencePadFrames ?? 8;   // trailing silence kept
+    this._targetRate         = opts.targetSampleRate    ?? 16000;
+    this._threshold          = opts.silenceThreshold    ?? 0.03;
+    this._padFrames          = opts.silencePadFrames    ?? 8;    // trailing silence kept
+    this._confirmFrames      = opts.speechConfirmFrames ?? 3;    // debounce transients
 
     // sampleRate is a global in AudioWorkletGlobalScope
-    this._ratio          = sampleRate / this._targetRate;
+    this._ratio              = sampleRate / this._targetRate;
 
-    this._silentCount    = 0;   // consecutive silent frames seen
-    this._speaking       = false;
+    this._silentCount        = 0;   // consecutive silent frames seen
+    this._aboveThreshCount   = 0;   // consecutive above-threshold frames seen
+    this._speaking           = false;
 
     // Listen for stop signal from main thread
     this.port.onmessage = (e) => {
@@ -46,16 +50,22 @@ class AudioRecorderProcessor extends AudioWorkletProcessor {
 
     const wasSpeaking = this._speaking;
     if (isSpeech) {
-      this._speaking    = true;
+      this._aboveThreshCount++;
       this._silentCount = 0;
+      // Require N consecutive above-threshold frames before declaring speech,
+      // so short transients (keyboard taps, chair scrapes) are ignored.
+      if (this._aboveThreshCount >= this._confirmFrames) {
+        this._speaking = true;
+      }
     } else {
+      this._aboveThreshCount = 0;
       this._silentCount++;
       if (this._silentCount > this._padFrames) this._speaking = false;
     }
 
     // Notify main thread on leading edge of each speech burst so it can flush
     // the player ring buffer and prevent stale audio backlog (barge-in support).
-    if (isSpeech && !wasSpeaking) {
+    if (this._speaking && !wasSpeaking) {
       this.port.postMessage({ type: 'speech_start' });
     }
 


### PR DESCRIPTION
## Summary
- Raises `silenceThreshold` from `0.01` (~-40 dBFS) to `0.03` (~-30 dBFS) — filters background noise (keyboard taps, chair scrapes) that were triggering false `speech_start` events and cutting off Melody mid-sentence
- Adds `speechConfirmFrames: 3` debounce: requires 3 consecutive above-threshold frames before declaring speech, rejecting short transients
- `app.js` now passes both values explicitly in `processorOptions` so the tuning is visible at the call site

## Test plan
- [ ] Start a session, let Melody speak, and make background noise (tap keyboard, move chair) — Melody should not be interrupted
- [ ] Speak normally — speech still triggers barge-in as expected
- [ ] Verify no regression in intentional barge-in: speaking over Melody while she's talking should still flush the player buffer

Fixes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)