### PR TITLE
fix: reset phase on ring buffer overflow to prevent audio speedup

### DIFF
--- a/client/audio-player-worklet.js
+++ b/client/audio-player-worklet.js
@@ -65,9 +65,14 @@ class AudioPlayerProcessor extends AudioWorkletProcessor {
   _enqueue(samples) {
     for (let i = 0; i < samples.length; i++) {
       if (this._size >= this._capacity) {
-        // Overflow: drop oldest sample to make room for fresh audio
+        // Overflow: drop oldest sample to make room for fresh audio.
+        // Reset _phase so the interpolation offset stays coherent with the
+        // new _readPos origin — without this, process() uses a stale phase
+        // that no longer corresponds to the actual buffer position, causing
+        // audible speedup during long audio bursts (e.g. job-reading).
         this._readPos = (this._readPos + 1) % this._capacity;
         this._size--;
+        this._phase = 0;
       }
       this._ring[this._writePos] = samples[i] / 32768.0;
       this._writePos = (this._writePos + 1) % this._capacity;


### PR DESCRIPTION
## Summary
- Adds `this._phase = 0` in `_enqueue` when the overflow guard fires
- Without this, `_readPos` advances to a new buffer origin but `_phase` still describes a fractional offset relative to the old origin — causing misaligned interpolation for the rest of the session
- Perceptible as speedup during long audio bursts (job descriptions read after tool calls)

## Root cause
During tool calls (`google_search`, `emit_job_card`), Gemini pre-generates the full job-reading response before streaming starts. The WebSocket delivers multiple seconds of audio in a rapid burst, triggering overflow in `_enqueue`. The existing fix for the 1.56% speedup bug (phase accumulator, PR #48) correctly tracks fractional offsets across quanta — but overflow was silently invalidating `_phase` by moving the buffer origin.

## Test plan
- [ ] Upload a resume and start a session
- [ ] Ask Melody to find jobs (triggers tool calls → audio burst)
- [ ] Confirm job descriptions play at normal speed with no speedup artifact
- [ ] Confirm flush still works (barge-in / session reset clears phase correctly)

Fixes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)