### PR TITLE
fix: correct phase accumulator during underrun to prevent post-tool-call speedup

### DIFF
--- a/client/audio-player-worklet.js
+++ b/client/audio-player-worklet.js
@@ -124,12 +124,23 @@ class AudioPlayerProcessor extends AudioWorkletProcessor {
     // Advance the ring buffer by exactly the integer number of input samples
     // consumed this quantum.  The fractional remainder carries over in _phase,
     // keeping total consumption perfectly in sync with the resampling ratio.
-    const totalAdvance = phase + outLen * ratio;
-    const intAdvance   = Math.floor(totalAdvance);
+    //
+    // When underrun occurs (actualAdvance < intAdvance), _phase must be set
+    // relative to actualAdvance (where _readPos actually landed), not intAdvance
+    // (where it would have landed without clamping).  Using intAdvance here
+    // accumulates (intAdvance - actualAdvance) samples of phantom phase per
+    // underrun frame; after ~200 frames of tool-call silence this causes
+    // sustained speedup when audio floods back in for job reading.
+    //
+    // On complete underrun (available === 0), reset to 0 — there is no sensible
+    // fractional offset to carry when the buffer is entirely empty, and leaving a
+    // large accumulated value would cause _readPos to skip far into the next burst.
+    const totalAdvance  = phase + outLen * ratio;
+    const intAdvance    = Math.floor(totalAdvance);
     const actualAdvance = Math.min(intAdvance, available);
     this._readPos = (this._readPos + actualAdvance) % this._capacity;
     this._size   -= actualAdvance;
-    this._phase   = totalAdvance - intAdvance;
+    this._phase   = available === 0 ? 0 : totalAdvance - actualAdvance;
 
     // Mono → stereo: copy channel 0 to any additional output channels
     for (let ch = 1; ch < outputs[0].length; ch++) {


### PR DESCRIPTION
## Summary
- Fixes phase accumulator corruption in `audio-player-worklet.js` that caused audio speedup when Melody reads job results after tool calls
- During the multi-second tool-call silence, the ring buffer drains and `process()` hits the underrun path ~200 times, each time accumulating phantom phase error
- When audio floods back in for job reading, `_phase` starts from a corrupted offset, causing every quantum to consume too many input samples → sustained speedup

## Root cause
`_phase` was set to `totalAdvance - intAdvance` (fractional remainder relative to where `_readPos` *would have* landed). During underrun, `actualAdvance < intAdvance`, so the correct value is `totalAdvance - actualAdvance` (relative to where it *actually* landed).

## Changes
- `this._phase = totalAdvance - actualAdvance` — relative to actual advance, not ideal
- `available === 0` case resets `_phase = 0` to avoid carrying unboundedly large stale value into the next audio burst

## Test plan
- [ ] Start a session, do short back-and-forth (audio sounds normal)
- [ ] Ask Melody to find jobs — she goes silent several seconds (tool calls)
- [ ] Verify job results are read back at normal pitch/speed (not faster/higher)
- [ ] Verify no regression in normal conversation audio

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)