### PR TITLE
fix: reset phase on any underrun to prevent cold-start audio speedup

### DIFF
--- a/client/audio-player-worklet.js
+++ b/client/audio-player-worklet.js
@@ -125,22 +125,24 @@ class AudioPlayerProcessor extends AudioWorkletProcessor {
     // consumed this quantum.  The fractional remainder carries over in _phase,
     // keeping total consumption perfectly in sync with the resampling ratio.
     //
-    // When underrun occurs (actualAdvance < intAdvance), _phase must be set
-    // relative to actualAdvance (where _readPos actually landed), not intAdvance
-    // (where it would have landed without clamping).  Using intAdvance here
-    // accumulates (intAdvance - actualAdvance) samples of phantom phase per
-    // underrun frame; after ~200 frames of tool-call silence this causes
-    // sustained speedup when audio floods back in for job reading.
+    // On any underrun (partial or complete), reset _phase = 0.
     //
-    // On complete underrun (available === 0), reset to 0 — there is no sensible
-    // fractional offset to carry when the buffer is entirely empty, and leaving a
-    // large accumulated value would cause _readPos to skip far into the next burst.
+    // Why: during underrun, we consumed all `available` samples and padded the
+    // rest with silence.  If we carried `totalAdvance - available` as the new
+    // phase, it would be > 1 (e.g. 54 when available=10, intAdvance=64).  On the
+    // next call the interpolation loop would start at pos=54 inside _temp, silently
+    // skipping the first 54 valid ring-buffer samples — exactly the "chipmunk"
+    // speedup observed on session start and after flush/post-search cold-start.
+    //
+    // Resetting to 0 is correct: the silence gap already filled the temporal hole;
+    // the next burst should start from the beginning of whatever is now in the
+    // buffer, not jump ahead to "catch up" to a clock that doesn't exist.
     const totalAdvance  = phase + outLen * ratio;
     const intAdvance    = Math.floor(totalAdvance);
     const actualAdvance = Math.min(intAdvance, available);
     this._readPos = (this._readPos + actualAdvance) % this._capacity;
     this._size   -= actualAdvance;
-    this._phase   = available === 0 ? 0 : totalAdvance - actualAdvance;
+    this._phase   = underrun ? 0 : totalAdvance - intAdvance;
 
     // Mono → stereo: copy channel 0 to any additional output channels
     for (let ch = 1; ch < outputs[0].length; ch++) {


### PR DESCRIPTION
## Root cause

PR #61 fixed the phase accumulator for the *complete* underrun case (tool-call silence) but left a bug in the *partial* underrun case.

When `0 < available < intAdvance` (partial underrun):
- `actualAdvance = available` (e.g., 10 samples)
- Old code: `_phase = totalAdvance - actualAdvance` (e.g., 64 − 10 = **54**)

On the next `process()` call with `phase = 54`, the interpolation loop starts at `pos = 54` inside `_temp`, silently **skipping the first 54 valid ring-buffer samples**. The worklet consumes audio faster than 1× — the chipmunk effect.

This triggers at:
1. **Session start** — buffer is empty, Gemini delivers audio in chunks, so the first several `process()` calls see `_size < intAdvance`
2. **Post-search / post-flush** — `speech_start` flushes the buffer, same cold-start condition before the longest utterance

## Fix

Reset `_phase = 0` on **any** underrun, not just complete underrun:

```js
this._phase = underrun ? 0 : totalAdvance - intAdvance;
```

The silence gap already fills the temporal hole. The next burst should start from position 0 in the buffer — there is no external sync clock that requires skipping ahead.

## Test plan
- [ ] Start a session — opening greeting plays at normal speed (no chipmunk on first utterance)
- [ ] Ask Melody to find jobs — wait for tool-call silence, then verify job results are read back at normal speed
- [ ] Barge-in mid-sentence — flush fires, next Melody response starts at normal speed
- [ ] Extended back-and-forth conversation — no regression in normal audio speed

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)