### PR TITLE
fix: emit all job cards before speaking and update to GA model string

### DIFF
--- a/server/melody_agent/agent.py
+++ b/server/melody_agent/agent.py
@@ -50,7 +50,7 @@ def create_agent(resume_data: dict) -> Agent:
     """
     return Agent(
         name="melody",
-        model="gemini-2.5-flash-native-audio-latest",
+        model="gemini-live-2.5-flash-native-audio",
         instruction=build_prompt(resume_data),
         tools=[google_search, emit_job_card],
         before_tool_callback=_before_tool,

--- a/server/melody_agent/prompts.py
+++ b/server/melody_agent/prompts.py
@@ -61,10 +61,12 @@ or more of a nice-to-have?"
 
 **Delivery phase:**
 - Present exactly 3 jobs. No more, no fewer.
-- For each job, call `emit_job_card` as you speak it aloud.
-- When presenting each job, explicitly reference something the user actually said in this \
-conversation to explain the fit. Do not present jobs as abstract matches — connect each \
-one to a specific priority or concern they voiced.
+- **First**, call `emit_job_card` for all 3 jobs back-to-back before saying anything \
+about the results. Do not speak while calling tools — emit all cards in one silent pass.
+- **Then**, after all 3 cards are emitted, speak the results aloud in a single turn.
+- When presenting each job aloud, explicitly reference something the user actually said \
+in this conversation to explain the fit. Do not present jobs as abstract matches — \
+connect each one to a specific priority or concern they voiced.
 
 ---
 


### PR DESCRIPTION
## Changes

### 1. Fix emit_job_card interleave (issue #58)

The prompt previously said *"call `emit_job_card` as you speak it aloud"*, causing the model to issue tool calls while actively streaming audio. On native audio Live models this concurrent tool + audio signal triggers the 1008 \"Operation is not implemented, or supported, or enabled\" crash.

New delivery phase instruction:
- **First**: call `emit_job_card` for all 3 jobs back-to-back (silent tool-call pass, no audio)
- **Then**: speak all results aloud in a single turn (no tool calls)

### 2. Update model string to GA version

`gemini-2.5-flash-native-audio-latest` is an unstable alias of unknown resolution.
Replaced with `gemini-live-2.5-flash-native-audio` — the GA release (Dec 12 2025, supported until Dec 2026).

## Test plan
- [ ] Start a session and complete the full flow (greeting → quiz → search → job delivery)
- [ ] Verify session does NOT crash with 1008 after job delivery
- [ ] Verify 3 job cards appear in the UI
- [ ] Verify Melody speaks the job results after the cards are rendered

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)