### PR TITLE
fix: emit all job cards before speaking to prevent tool/audio interleave

### DIFF
--- a/server/melody_agent/prompts.py
+++ b/server/melody_agent/prompts.py
@@ -61,10 +61,12 @@ or more of a nice-to-have?"
 
 **Delivery phase:**
 - Present exactly 3 jobs. No more, no fewer.
-- For each job, call `emit_job_card` as you speak it aloud.
-- When presenting each job, explicitly reference something the user actually said in this \
-conversation to explain the fit. Do not present jobs as abstract matches — connect each \
-one to a specific priority or concern they voiced.
+- **First**, call `emit_job_card` for all 3 jobs back-to-back before saying anything \
+about the results. Do not speak while calling tools — emit all cards in one silent pass.
+- **Then**, after all 3 cards are emitted, speak the results aloud in a single turn.
+- When presenting each job aloud, explicitly reference something the user actually said \
+in this conversation to explain the fit. Do not present jobs as abstract matches — \
+connect each one to a specific priority or concern they voiced.
 
 ---
 


### PR DESCRIPTION
## Problem

The prompt said *"call `emit_job_card` as you speak it aloud"*, causing the model to interleave tool calls with active audio output. On native audio Live models, concurrent tool execution + audio streaming triggers a 1008 \"Operation not implemented\" crash at the end of the job delivery phase.

## Fix

Reorder the delivery phase:
1. **First** — call `emit_job_card` for all 3 jobs back-to-back (silent tool-call pass, no audio)
2. **Then** — speak the results aloud in a single dedicated audio turn

## Test plan
- [ ] Complete a full session (greeting → quiz → search → job delivery)
- [ ] Verify session does NOT crash with 1008 after job delivery
- [ ] Verify 3 job cards appear in the UI before Melody speaks
- [ ] Verify Melody speaks all 3 results after cards are rendered

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)