### PR TITLE
fix: replace audio-player-worklet with ClearRight and fix app.js protocol

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -99,7 +99,8 @@ function showCTA() {
 }
 
 // --- Voice session state ---
-let audioCtx = null;
+let audioCtxRecorder = null;
+let audioCtxPlayer   = null;  // fixed 24 kHz — never closed, only suspended
 let recorderNode = null;
 let playerNode = null;
 let ws = null;
@@ -137,17 +138,24 @@ async function startVoiceSession(sid) {
   console.log('[melody] mic granted');
 
   // 2. AudioContext + worklets
-  audioCtx = new AudioContext();
-  if (audioCtx.state === 'suspended') await audioCtx.resume();
-  console.log('[melody] AudioContext state:', audioCtx.state);
-  await audioCtx.audioWorklet.addModule('audio-recorder-worklet.js');
+  // Recorder context: default device rate (browser chooses)
+  audioCtxRecorder = new AudioContext();
+  if (audioCtxRecorder.state === 'suspended') await audioCtxRecorder.resume();
+  console.log('[melody] recorder AudioContext state:', audioCtxRecorder.state);
+  await audioCtxRecorder.audioWorklet.addModule('audio-recorder-worklet.js');
   console.log('[melody] recorder worklet loaded');
-  await audioCtx.audioWorklet.addModule('audio-player-worklet.js');
-  console.log('[melody] player worklet loaded');
+
+  // Player context: fixed 24 kHz to match Gemini output — create once, suspend on stop
+  if (!audioCtxPlayer) {
+    audioCtxPlayer = new AudioContext({ sampleRate: 24000 });
+    await audioCtxPlayer.audioWorklet.addModule('audio-player-worklet.js');
+    console.log('[melody] player worklet loaded');
+  }
+  if (audioCtxPlayer.state === 'suspended') await audioCtxPlayer.resume();
 
   // Recorder: mic → worklet
-  const micSource = audioCtx.createMediaStreamSource(stream);
-  recorderNode = new AudioWorkletNode(audioCtx, 'audio-recorder-processor', {
+  const micSource = audioCtxRecorder.createMediaStreamSource(stream);
+  recorderNode = new AudioWorkletNode(audioCtxRecorder, 'audio-recorder-processor', {
     processorOptions: {
       targetSampleRate:    16000,
       silenceThreshold:    0.03,  // ~-30 dBFS; rejects background noise while catching speech
@@ -155,16 +163,15 @@ async function startVoiceSession(sid) {
     },
   });
   micSource.connect(recorderNode);
-  recorderNode.connect(audioCtx.destination); // keeps worklet alive; muted by default
+  recorderNode.connect(audioCtxRecorder.destination); // keeps worklet alive; muted by default
 
-  // Player: worklet → speakers
-  playerNode = new AudioWorkletNode(audioCtx, 'audio-player-processor', {
-    processorOptions: { inputSampleRate: 24000, bufferSeconds: 30 },
+  // Player: worklet → speakers (no processorOptions — ClearRight worklet uses none)
+  playerNode = new AudioWorkletNode(audioCtxPlayer, 'audio-player-processor', {
     numberOfInputs: 0,
     numberOfOutputs: 1,
     outputChannelCount: [1],
   });
-  playerNode.connect(audioCtx.destination);
+  playerNode.connect(audioCtxPlayer.destination);
 
   // 3. WebSocket
   console.log('[melody] opening WebSocket...');
@@ -184,7 +191,7 @@ async function startVoiceSession(sid) {
           ws.send(e.data); // ArrayBuffer (Int16 PCM 16kHz)
         }
       } else if (e.data?.type === 'speech_start') {
-        if (playerNode) playerNode.port.postMessage('flush');
+        if (playerNode) playerNode.port.postMessage({ type: 'flush' });
       }
     };
   });
@@ -192,7 +199,7 @@ async function startVoiceSession(sid) {
   ws.addEventListener('message', (e) => {
     if (e.data instanceof ArrayBuffer) {
       // Binary frame: agent audio (Int16 PCM 24kHz) → player worklet
-      playerNode.port.postMessage(e.data, [e.data]);
+      playerNode.port.postMessage({ type: 'audio_data', buffer: e.data }, [e.data]);
     } else if (typeof e.data === 'string') {
       // Text frame: JSON event
       let msg;
@@ -221,7 +228,10 @@ function stopVoiceSession() {
   ws = null;
   if (recorderNode) { recorderNode.port.postMessage('stop'); recorderNode.disconnect(); recorderNode = null; }
   if (playerNode) { playerNode.disconnect(); playerNode = null; }
-  if (audioCtx) { audioCtx.close(); audioCtx = null; }
+  if (audioCtxRecorder) { audioCtxRecorder.close(); audioCtxRecorder = null; }
+  // Suspend (not close) player context — closing and recreating causes Chrome to silently
+  // fail when re-adding the worklet module on the next session start.
+  if (audioCtxPlayer) audioCtxPlayer.suspend();
   meetMelodyBtn.textContent = 'Session ended';
 }
 

--- a/client/audio-player-worklet.js
+++ b/client/audio-player-worklet.js
@@ -1,143 +1,55 @@
 /**
- * audio-player-worklet.js
+ * An AudioWorkletProcessor for playing back raw PCM audio chunks.
  *
- * AudioWorkletProcessor that buffers incoming Int16 PCM chunks received from
- * the WebSocket (via the main thread), resamples from the input rate (default
- * 24 kHz — Gemini Live output) to the AudioContext sample rate, and writes
- * them to the output channel.
- *
- * Handles buffer underrun by outputting silence (zeros) — no clicks or pops.
- *
- * Constructor processorOptions:
- *   inputSampleRate  {number}  PCM rate of incoming data (default: 24000)
- *   bufferSeconds    {number}  Ring buffer size in seconds (default: 4)
- *
- * Messages FROM main thread:
- *   ArrayBuffer  — Int16 PCM samples to enqueue
- *   'flush'      — clear the buffer (e.g. on barge-in / session reset)
- *
- * Messages TO main thread:
- *   { type: 'underrun' } — emitted once per underrun event (for UI feedback)
+ * It buffers incoming audio chunks and plays them out smoothly.
+ * It includes a 'flush' command to clear the buffer, which is
+ * essential for barge-in (stopping playback immediately).
  */
 class AudioPlayerProcessor extends AudioWorkletProcessor {
-  constructor(options) {
+  constructor() {
     super();
-
-    const opts           = options.processorOptions ?? {};
-    this._inputRate      = opts.inputSampleRate ?? 24000;
-    const bufSeconds     = opts.bufferSeconds   ?? 4;
-
-    // Ring buffer stores Float32 samples at the input rate
-    this._capacity       = Math.ceil(this._inputRate * bufSeconds);
-    this._ring           = new Float32Array(this._capacity);
-    this._writePos       = 0;
-    this._readPos        = 0;
-    this._size           = 0;
-
-    // Phase accumulator: fractional input-sample offset carried across quanta.
-    // Ensures each process() call advances the read pointer by exactly the right
-    // number of integer input samples rather than over-consuming by 1 per quantum
-    // (which would cause a constant ~1.56% speedup on long utterances).
-    this._phase          = 0;
-
-    // Pre-allocate temp buffer for one process() block.
-    // ratio = inputRate / contextRate; if ratio > 1 we need more input samples
-    // than output samples per block.  +2 gives the interpolation tail plus slack.
-    const ratio          = this._inputRate / sampleRate;
-    this._tempSize       = Math.ceil(128 * ratio) + 2;
-    this._temp           = new Float32Array(this._tempSize);
-
-    this._wasUnderrun    = false;
-
-    this.port.onmessage = (e) => {
-      if (e.data instanceof ArrayBuffer) {
-        this._enqueue(new Int16Array(e.data));
-      } else if (e.data === 'flush') {
-        this._writePos = 0;
-        this._readPos  = 0;
-        this._size     = 0;
-        this._phase    = 0;
+    this.audioQueue = [];
+    this.currentChunk = null;
+    this.currentChunkIndex = 0;
+    
+    this.port.onmessage = (event) => {
+      if (event.data.type === 'audio_data') {
+        // Add new audio data to our buffer
+        const pcmData = new Int16Array(event.data.buffer);
+        this.audioQueue.push(pcmData);
+      } else if (event.data.type === 'flush') {
+        // --- THIS IS THE CRITICAL BARGE-IN LOGIC ---
+        // Clear the buffer immediately
+        this.audioQueue = [];
+        this.currentChunk = null;
+        this.currentChunkIndex = 0;
+        console.log("Audio player flushed.");
       }
     };
   }
 
-  /** Convert Int16 samples to Float32 and append to the ring buffer. */
-  _enqueue(samples) {
-    for (let i = 0; i < samples.length; i++) {
-      if (this._size >= this._capacity) {
-        // Overflow: drop oldest sample to make room for fresh audio.
-        // Reset _phase so the interpolation offset stays coherent with the
-        // new _readPos origin — without this, process() uses a stale phase
-        // that no longer corresponds to the actual buffer position, causing
-        // audible speedup during long audio bursts (e.g. job-reading).
-        this._readPos = (this._readPos + 1) % this._capacity;
-        this._size--;
-        this._phase = 0;
+  process(inputs, outputs, parameters) {
+    const outputChannel = outputs[0][0];
+
+    for (let i = 0; i < outputChannel.length; i++) {
+      if (!this.currentChunk || this.currentChunkIndex >= this.currentChunk.length) {
+        if (this.audioQueue.length > 0) {
+          this.currentChunk = this.audioQueue.shift();
+          this.currentChunkIndex = 0;
+        } else {
+          outputChannel[i] = 0;
+          continue;
+        }
       }
-      this._ring[this._writePos] = samples[i] / 32768.0;
-      this._writePos = (this._writePos + 1) % this._capacity;
-      this._size++;
-    }
-  }
 
-  process(inputs, outputs) {
-    const channel = outputs[0]?.[0];
-    if (!channel) return true;
-
-    const outLen   = channel.length;                     // 128 frames (render quantum)
-    const ratio    = this._inputRate / sampleRate;       // e.g. 24000/48000 = 0.5
-    const phase    = this._phase;                        // fractional offset [0, 1)
-
-    // How many integer input samples to peek for interpolation:
-    //   last 'a' index = floor(phase + (outLen-1)*ratio)
-    //   need +1 for the 'b' interpolation tail, +1 to convert to count
-    const inNeeded = Math.floor(phase + (outLen - 1) * ratio) + 2;
-
-    // Peek inNeeded samples from the ring buffer without advancing readPos yet.
-    // We will advance by the integer number of samples consumed after interpolation.
-    const available = Math.min(inNeeded, this._size);
-    const underrun  = available < inNeeded;
-
-    for (let i = 0; i < available; i++) {
-      this._temp[i] = this._ring[(this._readPos + i) % this._capacity];
-    }
-    for (let i = available; i < inNeeded; i++) {
-      this._temp[i] = 0; // silence padding
-    }
-
-    // Notify main thread on leading edge of each underrun (not every block)
-    if (underrun && !this._wasUnderrun) {
-      this.port.postMessage({ type: 'underrun' });
-    }
-    this._wasUnderrun = underrun;
-
-    // Linear interpolation resample: inputRate → AudioContext sample rate
-    for (let i = 0; i < outLen; i++) {
-      const pos  = phase + i * ratio;
-      const idx  = Math.floor(pos);
-      const frac = pos - idx;
-      const a    = this._temp[idx];
-      const b    = idx + 1 < inNeeded ? this._temp[idx + 1] : a;
-      channel[i] = a + frac * (b - a);
-    }
-
-    // Advance the ring buffer by exactly the integer number of input samples
-    // consumed this quantum.  The fractional remainder carries over in _phase,
-    // keeping total consumption perfectly in sync with the resampling ratio.
-    const totalAdvance = phase + outLen * ratio;
-    const intAdvance   = Math.floor(totalAdvance);
-    const actualAdvance = Math.min(intAdvance, available);
-    this._readPos = (this._readPos + actualAdvance) % this._capacity;
-    this._size   -= actualAdvance;
-    this._phase   = totalAdvance - intAdvance;
-
-    // Mono → stereo: copy channel 0 to any additional output channels
-    for (let ch = 1; ch < outputs[0].length; ch++) {
-      outputs[0][ch].set(channel);
+      const sample = this.currentChunk[this.currentChunkIndex];
+      outputChannel[i] = sample / 32768.0;
+      this.currentChunkIndex++;
     }
 
     return true;
   }
 }
 
-registerProcessor('audio-player-processor', AudioPlayerProcessor);
+registerProcessor("audio-player-processor", AudioPlayerProcessor);
+


### PR DESCRIPTION
Closes #70

## Summary
- Replace `client/audio-player-worklet.js` with the ClearRight simple array-queue version (no ring buffer, no resampling, no phase state to corrupt)
- Fix flush message format: `'flush'` string → `{ type: 'flush' }` object so barge-in actually clears the buffer
- Split `AudioContext` into separate recorder (default rate) and player (fixed 24 kHz) contexts
- Player audio frames now use `{ type: 'audio_data', buffer }` with transferable
- Player context is suspended (not closed) on session stop to avoid Chrome's silent failure when re-adding a worklet module

## Test plan
- [ ] Start a session — Melody's voice plays back without chipmunk speedup after a `google_search` tool call
- [ ] Speak while Melody is talking — barge-in flushes the buffer and Melody stops immediately
- [ ] End and restart a session — player context resumes cleanly without errors in the console

🤖 Generated with [Claude Code](https://claude.com/claude-code)