### PR TITLE
fix: update WebSocket audio protocol to base64 JSON (#72)

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -98,6 +98,21 @@ function showCTA() {
   ctaSection.hidden = false;
 }
 
+// --- Base64 ↔ ArrayBuffer utilities (for WebSocket audio protocol) ---
+function arrayBufferToBase64(buffer) {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i++) binary += String.fromCharCode(bytes[i]);
+  return btoa(binary);
+}
+
+function base64ToArrayBuffer(base64) {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes.buffer;
+}
+
 // --- Voice session state ---
 let audioCtxRecorder = null;
 let audioCtxPlayer   = null;  // fixed 24 kHz — never closed, only suspended
@@ -176,18 +191,18 @@ async function startVoiceSession(sid) {
   console.log('[melody] opening WebSocket...');
   const proto = location.protocol === 'https:' ? 'wss' : 'ws';
   ws = new WebSocket(`${proto}://${location.host}/ws/${sid}`);
-  ws.binaryType = 'arraybuffer';
 
   ws.addEventListener('open', () => {
     meetMelodyBtn.textContent = 'End session';
     meetMelodyBtn.disabled = false;
-    // Forward PCM chunks from recorder worklet → WebSocket.
+    // Forward PCM chunks from recorder worklet → WebSocket as base64 JSON.
     // On speech_start, flush the player ring buffer so stale audio from
     // Melody's previous turn doesn't delay playback of the next response.
     recorderNode.port.onmessage = (e) => {
       if (e.data?.type === 'audio_data') {
         if (ws.readyState === WebSocket.OPEN) {
-          ws.send(e.data.buffer); // ArrayBuffer (Int16 PCM 16kHz)
+          const base64 = arrayBufferToBase64(e.data.buffer);
+          ws.send(JSON.stringify({ mime_type: 'audio/pcm', data: base64 }));
         }
       } else if (e.data?.type === 'speech_start') {
         if (playerNode) playerNode.port.postMessage({ type: 'flush' });
@@ -198,16 +213,26 @@ async function startVoiceSession(sid) {
   });
 
   ws.addEventListener('message', (e) => {
-    if (e.data instanceof ArrayBuffer) {
-      // Binary frame: agent audio (Int16 PCM 24kHz) → player worklet
-      playerNode.port.postMessage({ type: 'audio_data', buffer: e.data }, [e.data]);
-    } else if (typeof e.data === 'string') {
-      // Text frame: JSON event
-      let msg;
-      try { msg = JSON.parse(e.data); } catch { return; }
-      if (msg.type === 'job_card') {
-        renderJobCard(msg); // implemented in issue #6.1
+    if (typeof e.data !== 'string') return;
+    let msg;
+    try { msg = JSON.parse(e.data); } catch { return; }
+
+    // Audio + control envelope from agent
+    if (msg.parts) {
+      for (const part of msg.parts) {
+        if ((part.type === 'audio/pcm' || part.mime_type === 'audio/pcm') && part.data) {
+          const buffer = base64ToArrayBuffer(part.data);
+          playerNode.port.postMessage({ type: 'audio_data', buffer }, [buffer]);
+        }
       }
+    }
+    // Barge-in: agent was interrupted — flush buffered playback immediately
+    if (msg.interrupted) {
+      if (playerNode) playerNode.port.postMessage({ type: 'flush' });
+    }
+    // Job card event — sent as a separate frame by the server
+    if (msg.type === 'job_card') {
+      renderJobCard(msg);
     }
   });
 

--- a/server/main.py
+++ b/server/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 import json
 import os
 import uuid
@@ -82,18 +83,23 @@ async def websocket_session(websocket: WebSocket, session_id: str):
     )
 
     async def receive_audio():
-        """Browser → LiveRequestQueue: forward raw PCM blobs."""
+        """Browser → LiveRequestQueue: decode base64 JSON envelope and forward PCM."""
         try:
             while True:
-                data = await websocket.receive_bytes()
+                text = await websocket.receive_text()
+                try:
+                    msg = json.loads(text)
+                    pcm_data = base64.b64decode(msg["data"])
+                except (json.JSONDecodeError, KeyError, Exception):
+                    continue  # drop malformed frames
                 live_queue.send_realtime(
-                    genai_types.Blob(data=data, mime_type="audio/pcm;rate=16000")
+                    genai_types.Blob(data=pcm_data, mime_type="audio/pcm;rate=16000")
                 )
         except WebSocketDisconnect:
             live_queue.close()
 
     async def send_events():
-        """ADK events → browser: audio chunks and job cards."""
+        """ADK events → browser: base64 JSON audio envelope and job cards."""
         try:
             async for event in runner.run_live(
                 user_id="user",
@@ -101,11 +107,23 @@ async def websocket_session(websocket: WebSocket, session_id: str):
                 live_request_queue=live_queue,
                 run_config=run_config,
             ):
-                # Forward agent audio as binary frames
+                # Collect audio parts and send as a single JSON envelope
+                audio_parts = []
                 if event.content and event.content.parts:
                     for part in event.content.parts:
                         if part.inline_data and part.inline_data.data:
-                            await websocket.send_bytes(part.inline_data.data)
+                            audio_parts.append({
+                                "type": "audio/pcm",
+                                "data": base64.b64encode(part.inline_data.data).decode("ascii"),
+                            })
+
+                if audio_parts or event.turn_complete or getattr(event, "interrupted", False):
+                    envelope: dict = {
+                        "parts": audio_parts,
+                        "turn_complete": bool(event.turn_complete),
+                        "interrupted": bool(getattr(event, "interrupted", False)),
+                    }
+                    await websocket.send_text(json.dumps(envelope))
 
                 # After each turn flush pending job cards from session state
                 if event.turn_complete:


### PR DESCRIPTION
## Summary

- **`client/app.js`**: adds `arrayBufferToBase64`/`base64ToArrayBuffer` utilities; outbound mic audio is now JSON-encoded `{ mime_type: "audio/pcm", data: <base64> }`; inbound handler parses `{ parts, turn_complete, interrupted }` envelope, decodes each audio part to ArrayBuffer and forwards to player worklet; flushes player on `interrupted` flag; `ws.binaryType` removed (no longer sending/receiving binary frames)
- **`server/main.py`**: `receive_audio()` switches from `receive_bytes()` to `receive_text()`, JSON-parses the envelope, base64-decodes PCM before forwarding to ADK; `send_events()` encodes ADK audio bytes as base64 and wraps in `{ parts, turn_complete, interrupted }` JSON envelope; job cards continue to be sent as separate `{ type: "job_card", ... }` text frames

Closes #72. Depends on #70 and #71 (both already merged).

## Test plan
- [ ] Upload a resume, start a voice session — mic audio flows to server (check server logs show PCM arriving)
- [ ] Agent audio plays back (no silence / playback errors)
- [ ] Barge-in: speak while agent is talking — player flushes and agent stops
- [ ] `turn_complete` events arrive; job cards render after agent turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)