### PR TITLE
fix: use gemini-2.5-flash-native-audio-preview-12-2025 (Gemini API)

### DIFF
--- a/server/melody_agent/agent.py
+++ b/server/melody_agent/agent.py
@@ -50,7 +50,7 @@ def create_agent(resume_data: dict) -> Agent:
     """
     return Agent(
         name="melody",
-        model="gemini-live-2.5-flash-native-audio",
+        model="gemini-2.5-flash-native-audio-preview-12-2025",
         instruction=build_prompt(resume_data),
         tools=[google_search, emit_job_card],
         before_tool_callback=_before_tool,


### PR DESCRIPTION
## Summary
- Corrects the model ID to `gemini-2.5-flash-native-audio-preview-12-2025` for Gemini API (non-Vertex) usage
- The previous fix used `gemini-live-2.5-flash-native-audio` which is a Vertex AI model name — it returned 1008 "not found for API version v1alpha" since `GOOGLE_GENAI_USE_VERTEXAI=0`
- Model string per `CLAUDE.md` spec

## Test plan
- [ ] Run server locally and confirm WebSocket session opens without 1008 error
- [ ] Trigger `google_search` tool call and confirm session continues

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)