### PR TITLE
fix: revert model to -latest and fix response_modalities enum (issue #77)

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -75,7 +75,7 @@ async def websocket_session(websocket: WebSocket, session_id: str):
     live_queue = LiveRequestQueue()
     run_config = RunConfig(
         streaming_mode=StreamingMode.BIDI,
-        response_modalities=["AUDIO"],
+        response_modalities=[genai_types.Modality.AUDIO],
         context_window_compression=genai_types.ContextWindowCompressionConfig(
             sliding_window=genai_types.SlidingWindow(target_tokens=20000),
             trigger_tokens=25000,

--- a/server/melody_agent/agent.py
+++ b/server/melody_agent/agent.py
@@ -50,7 +50,7 @@ def create_agent(resume_data: dict) -> Agent:
     """
     return Agent(
         name="melody",
-        model="gemini-2.5-flash-native-audio-preview-12-2025",
+        model="gemini-2.5-flash-native-audio-latest",
         instruction=build_prompt(resume_data),
         tools=[google_search, emit_job_card],
         before_tool_callback=_before_tool,


### PR DESCRIPTION
## Summary
- Reverts model ID to `gemini-2.5-flash-native-audio-latest` — confirmed working (ClearRight uses same string); the preview model caused 1011 "Deadline expired" errors
- Fixes `response_modalities` to use `genai_types.Modality.AUDIO` enum instead of plain string `"AUDIO"`, eliminating the Pydantic serialization warning that likely contributed to 1008 crashes on tool calls

## Test plan
- [ ] Restart server and connect a voice session — confirm no 1008 or 1011 errors
- [ ] Trigger `google_search` tool call and confirm session continues
- [ ] Confirm no Pydantic serialization warnings in logs

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)