### PR TITLE
fix: remove response_modalities from RunConfig (issue #81)

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -75,7 +75,6 @@ async def websocket_session(websocket: WebSocket, session_id: str):
     live_queue = LiveRequestQueue()
     run_config = RunConfig(
         streaming_mode=StreamingMode.BIDI,
-        response_modalities=[genai_types.Modality.AUDIO],
         context_window_compression=genai_types.ContextWindowCompressionConfig(
             sliding_window=genai_types.SlidingWindow(target_tokens=20000),
             trigger_tokens=25000,


### PR DESCRIPTION
## Summary
- Removes `response_modalities=[genai_types.Modality.AUDIO]` from `RunConfig` in `server/main.py`
- This eliminates the Pydantic serialization warning introduced by the ADK 1.26.0 regression
- The native audio model defaults to audio output without the field, so no behavior change

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)