### PR TITLE
fix: reject fabricated URLs in before_tool_callback for emit_job_card

### DIFF
--- a/server/melody_agent/agent.py
+++ b/server/melody_agent/agent.py
@@ -1,6 +1,7 @@
 """Melody ADK agent definition."""
 
 import time
+import urllib.parse
 
 from google.adk.agents import Agent
 from google.adk.tools import google_search
@@ -14,6 +15,20 @@ def _before_tool(tool, args, tool_context):
     """Log tool call start and record timestamp for elapsed-time tracking."""
     tool_context.state[f"_tool_start_{tool.name}"] = time.time()
     print(f"[tool] {tool.name} START | args={args}", flush=True)
+
+    if tool.name == "emit_job_card":
+        url = args.get("url", "")
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme != "https" or not parsed.netloc or parsed.path in ("", "/"):
+            return {
+                "error": (
+                    f"Invalid url '{url}'. Must be a full https:// job posting URL "
+                    "copied verbatim from a google_search result (e.g. "
+                    "https://www.indeed.com/viewjob?jk=abc123). "
+                    "Run google_search first and use a URL from the results."
+                )
+            }
+
     return None
 
 


### PR DESCRIPTION
## Summary
- Adds URL validation in `_before_tool` when `tool.name == "emit_job_card"`
- Bare domains (e.g. `indeed.com`) fail the path check and return an error dict, skipping tool execution and prompting the agent to retry with a real URL from `google_search`
- Imports `urllib.parse` at the top of `agent.py`

Fixes #82

## Test plan
- [ ] Run `adk web` and start a voice session
- [ ] Confirm bare domain URLs (e.g. `indeed.com`) are rejected with an informative error
- [ ] Confirm full `https://` job posting URLs pass validation and emit job cards normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)