### PR TITLE
fix: ban fabricated URLs in prompt and fix job delivery duplication

### DIFF
--- a/server/melody_agent/agent.py
+++ b/server/melody_agent/agent.py
@@ -22,10 +22,11 @@ def _before_tool(tool, args, tool_context):
         if parsed.scheme != "https" or not parsed.netloc or parsed.path in ("", "/"):
             return {
                 "error": (
-                    f"Invalid url '{url}'. Must be a full https:// job posting URL "
+                    f"Invalid url '{url}'. The url must be a full https:// job posting URL "
                     "copied verbatim from a google_search result (e.g. "
                     "https://www.indeed.com/viewjob?jk=abc123). "
-                    "Run google_search first and use a URL from the results."
+                    "Do not retry this job — skip it and pick a different job from the "
+                    "search results that has a full posting URL."
                 )
             }
 

--- a/server/melody_agent/prompts.py
+++ b/server/melody_agent/prompts.py
@@ -66,7 +66,16 @@ or more of a nice-to-have?"
 - Every job you present MUST come from the `google_search` results. Use the real company \
 names, job titles, and URLs from the search. Never invent a company, title, or URL. \
 Never use example.com or placeholder URLs.
-- For each job, call `emit_job_card` as you speak it aloud.
+- URL RULE: The `url` field in `emit_job_card` MUST be copied verbatim from a URL that \
+appeared in a `google_search` result during this session. Do NOT construct, guess, shorten, \
+or recall URLs from memory. A bare domain (e.g. `indeed.com` or `https://indeed.com`) is \
+not a job posting URL. If you do not have a full posting URL from the search results, \
+skip that job and pick another from the results.
+- For each job, call `emit_job_card` — this sends the full card (title, company, salary, \
+URL) directly to the user's screen. Do not read those fields back. Speak only the one \
+sentence connecting this job to something specific they told you. Then move to the next \
+job. After the third job, close warmly — do not summarize or restate any job you already \
+presented.
 - When presenting each job, explicitly reference something the user actually said in this \
 conversation to explain the fit. Do not present jobs as abstract matches — connect each \
 one to a specific priority or concern they voiced.


### PR DESCRIPTION
## Summary
- Adds explicit URL sourcing rule to delivery phase in `prompts.py`: `url` must be copied verbatim from `google_search` results; bare domains (e.g. `https://indeed.com`) are explicitly forbidden; if no full posting URL is available, skip that job (fixes #83)
- Tells the model that `emit_job_card` renders the full card on screen — speak only the one-sentence fit reason per job, no summary pass after the third (fixes #85)
- Updates `before_tool_callback` error message to say "skip this job, pick another" instead of "retry" — breaks the fabricated-URL retry loop that was causing context overflow and 1008 crashes

## Why together
Both issues are in `prompts.py` and are directly coupled: #83's retry loop (caused by missing a "skip" instruction) was the proximate cause of the 1008 crash introduced by #86. Fixing #85 also reduces `emit_job_card` call volume from 6→3, shrinking the retry surface further.

## Test plan
- [ ] Each job is spoken about exactly once
- [ ] `emit_job_card` fires 3 times, not 6
- [ ] No verbal summary after the third job
- [ ] Bare domain URLs are rejected and agent skips to a different job rather than retrying
- [ ] Session completes without a 1008 crash

Fixes #83
Fixes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)