### PR TITLE
security: load GOOGLE_API_KEY from Secret Manager

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -11,11 +11,6 @@ if [ -z "${GOOGLE_CLOUD_PROJECT:-}" ]; then
   exit 1
 fi
 
-if [ -z "${GOOGLE_API_KEY:-}" ]; then
-  echo "ERROR: GOOGLE_API_KEY is not set." >&2
-  exit 1
-fi
-
 echo "Project : $GOOGLE_CLOUD_PROJECT"
 echo "Service : $SERVICE_NAME"
 echo "Region  : $REGION"
@@ -39,7 +34,8 @@ gcloud run deploy "$SERVICE_NAME" \
   --project "$GOOGLE_CLOUD_PROJECT" \
   --platform managed \
   --allow-unauthenticated \
-  --set-env-vars "GOOGLE_API_KEY=${GOOGLE_API_KEY},GOOGLE_GENAI_USE_VERTEXAI=0" \
+  --set-secrets "GOOGLE_API_KEY=GOOGLE_API_KEY:latest" \
+  --set-env-vars "GOOGLE_GENAI_USE_VERTEXAI=0" \
   --memory 512Mi \
   --timeout 3600
 


### PR DESCRIPTION
## Summary
- Removes `GOOGLE_API_KEY` from plain `--set-env-vars` (visible in GCP console / deploy logs)
- Stores key in GCP Secret Manager (`GOOGLE_API_KEY` secret, version `latest`)
- Cloud Run service account granted `roles/secretmanager.secretAccessor`
- `deploy.sh` no longer requires `GOOGLE_API_KEY` to be set in the local environment

## Test plan
- [ ] Deploy succeeds with `./deploy.sh` (no `GOOGLE_API_KEY` env var needed locally)
- [ ] Live URL responds and voice session works end-to-end
- [ ] Key is NOT visible in Cloud Run environment variables in GCP console

🤖 Generated with [Claude Code](https://claude.com/claude-code)