### PR TITLE
revert: undo URL validation and prompt changes from PRs #86/#87

### DIFF
--- a/server/melody_agent/agent.py
+++ b/server/melody_agent/agent.py
@@ -1,7 +1,6 @@
 """Melody ADK agent definition."""
 
 import time
-import urllib.parse
 
 from google.adk.agents import Agent
 from google.adk.tools import google_search
@@ -15,21 +14,6 @@ def _before_tool(tool, args, tool_context):
     """Log tool call start and record timestamp for elapsed-time tracking."""
     tool_context.state[f"_tool_start_{tool.name}"] = time.time()
     print(f"[tool] {tool.name} START | args={args}", flush=True)
-
-    if tool.name == "emit_job_card":
-        url = args.get("url", "")
-        parsed = urllib.parse.urlparse(url)
-        if parsed.scheme != "https" or not parsed.netloc or parsed.path in ("", "/"):
-            return {
-                "error": (
-                    f"Invalid url '{url}'. The url must be a full https:// job posting URL "
-                    "copied verbatim from a google_search result (e.g. "
-                    "https://www.indeed.com/viewjob?jk=abc123). "
-                    "Do not retry this job — skip it and pick a different job from the "
-                    "search results that has a full posting URL."
-                )
-            }
-
     return None
 
 

--- a/server/melody_agent/prompts.py
+++ b/server/melody_agent/prompts.py
@@ -66,16 +66,7 @@ or more of a nice-to-have?"
 - Every job you present MUST come from the `google_search` results. Use the real company \
 names, job titles, and URLs from the search. Never invent a company, title, or URL. \
 Never use example.com or placeholder URLs.
-- URL RULE: The `url` field in `emit_job_card` MUST be copied verbatim from a URL that \
-appeared in a `google_search` result during this session. Do NOT construct, guess, shorten, \
-or recall URLs from memory. A bare domain (e.g. `indeed.com` or `https://indeed.com`) is \
-not a job posting URL. If you do not have a full posting URL from the search results, \
-skip that job and pick another from the results.
-- For each job, call `emit_job_card` — this sends the full card (title, company, salary, \
-URL) directly to the user's screen. Do not read those fields back. Speak only the one \
-sentence connecting this job to something specific they told you. Then move to the next \
-job. After the third job, close warmly — do not summarize or restate any job you already \
-presented.
+- For each job, call `emit_job_card` as you speak it aloud.
 - When presenting each job, explicitly reference something the user actually said in this \
 conversation to explain the fit. Do not present jobs as abstract matches — connect each \
 one to a specific priority or concern they voiced.


### PR DESCRIPTION
## Summary
- Reverts `server/melody_agent/agent.py` URL validation added in PR #86
- Reverts `server/melody_agent/prompts.py` delivery/URL rule changes added in PR #87
- Audio quality regressed and job search stopped working after these changes
- Secret Manager change (PR #88) is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)