### PR TITLE
feat: add architecture.svg to assets/ (issue #22)

### DIFF
--- a/assets/architecture.svg
+++ b/assets/architecture.svg
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 620" font-family="'Segoe UI', system-ui, sans-serif" font-size="13">
+
+  <!-- Background -->
+  <rect width="900" height="620" fill="#0f1117" rx="12"/>
+
+  <!-- Title -->
+  <text x="450" y="38" text-anchor="middle" fill="#e2e8f0" font-size="18" font-weight="700">Melody — Architecture</text>
+
+  <!-- ───────────────────────────────────────────────────────────
+       BROWSER box
+  ──────────────────────────────────────────────────────────── -->
+  <rect x="30" y="70" width="180" height="480" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1.5"/>
+  <text x="120" y="92" text-anchor="middle" fill="#94a3b8" font-size="11" font-weight="600" letter-spacing="1">BROWSER</text>
+
+  <!-- Resume Upload UI -->
+  <rect x="46" y="102" width="148" height="50" rx="5" fill="#0f172a" stroke="#475569" stroke-width="1"/>
+  <text x="120" y="122" text-anchor="middle" fill="#cbd5e1" font-size="11">Resume Upload UI</text>
+  <text x="120" y="138" text-anchor="middle" fill="#64748b" font-size="10">PDF / plain-text</text>
+
+  <!-- Audio Worklet -->
+  <rect x="46" y="170" width="148" height="60" rx="5" fill="#0f172a" stroke="#475569" stroke-width="1"/>
+  <text x="120" y="192" text-anchor="middle" fill="#cbd5e1" font-size="11">Audio Worklet</text>
+  <text x="120" y="208" text-anchor="middle" fill="#64748b" font-size="10">PCM 16 kHz capture</text>
+  <text x="120" y="222" text-anchor="middle" fill="#64748b" font-size="10">base64 JSON envelope</text>
+
+  <!-- Audio Player Worklet -->
+  <rect x="46" y="248" width="148" height="60" rx="5" fill="#0f172a" stroke="#475569" stroke-width="1"/>
+  <text x="120" y="270" text-anchor="middle" fill="#cbd5e1" font-size="11">Audio Player Worklet</text>
+  <text x="120" y="286" text-anchor="middle" fill="#64748b" font-size="10">PCM 24 kHz playback</text>
+  <text x="120" y="300" text-anchor="middle" fill="#64748b" font-size="10">base64 JSON decode</text>
+
+  <!-- Job Card Renderer -->
+  <rect x="46" y="326" width="148" height="50" rx="5" fill="#0f172a" stroke="#475569" stroke-width="1"/>
+  <text x="120" y="347" text-anchor="middle" fill="#cbd5e1" font-size="11">Job Card Renderer</text>
+  <text x="120" y="363" text-anchor="middle" fill="#64748b" font-size="10">JSON {"type":"job_card"}</text>
+
+  <!-- Static files label -->
+  <rect x="46" y="394" width="148" height="40" rx="5" fill="#0f172a" stroke="#334155" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="120" y="412" text-anchor="middle" fill="#64748b" font-size="10">StaticFiles</text>
+  <text x="120" y="427" text-anchor="middle" fill="#64748b" font-size="10">client/ → FastAPI mount</text>
+
+  <!-- ───────────────────────────────────────────────────────────
+       FASTAPI / SERVER box
+  ──────────────────────────────────────────────────────────── -->
+  <rect x="270" y="70" width="200" height="480" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1.5"/>
+  <text x="370" y="92" text-anchor="middle" fill="#94a3b8" font-size="11" font-weight="600" letter-spacing="1">FASTAPI SERVER</text>
+
+  <!-- POST /upload -->
+  <rect x="286" y="102" width="168" height="66" rx="5" fill="#0f172a" stroke="#475569" stroke-width="1"/>
+  <text x="370" y="122" text-anchor="middle" fill="#cbd5e1" font-size="11" font-weight="600">POST /upload</text>
+  <text x="370" y="138" text-anchor="middle" fill="#64748b" font-size="10">validate content-type</text>
+  <text x="370" y="153" text-anchor="middle" fill="#64748b" font-size="10">≤ 20 MB size check</text>
+
+  <!-- WebSocket /ws/{session_id} -->
+  <rect x="286" y="188" width="168" height="76" rx="5" fill="#0f172a" stroke="#475569" stroke-width="1"/>
+  <text x="370" y="208" text-anchor="middle" fill="#cbd5e1" font-size="11" font-weight="600">WebSocket</text>
+  <text x="370" y="222" text-anchor="middle" fill="#9ca3af" font-size="10">/ws/{session_id}</text>
+  <text x="370" y="238" text-anchor="middle" fill="#64748b" font-size="10">receive_audio task</text>
+  <text x="370" y="253" text-anchor="middle" fill="#64748b" font-size="10">send_events task</text>
+
+  <!-- Session Store -->
+  <rect x="286" y="284" width="168" height="50" rx="5" fill="#0f172a" stroke="#475569" stroke-width="1"/>
+  <text x="370" y="306" text-anchor="middle" fill="#cbd5e1" font-size="11">Session Store</text>
+  <text x="370" y="322" text-anchor="middle" fill="#64748b" font-size="10">dict[session_id → resume]</text>
+
+  <!-- InMemoryRunner -->
+  <rect x="286" y="354" width="168" height="66" rx="5" fill="#0f172a" stroke="#7c3aed" stroke-width="1.5"/>
+  <text x="370" y="374" text-anchor="middle" fill="#c4b5fd" font-size="11" font-weight="600">InMemoryRunner</text>
+  <text x="370" y="390" text-anchor="middle" fill="#64748b" font-size="10">ADK runner per session</text>
+  <text x="370" y="406" text-anchor="middle" fill="#64748b" font-size="10">LiveRequestQueue (BIDI)</text>
+
+  <!-- ───────────────────────────────────────────────────────────
+       ADK MELODY AGENT box
+  ──────────────────────────────────────────────────────────── -->
+  <rect x="530" y="70" width="200" height="320" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1.5"/>
+  <text x="630" y="92" text-anchor="middle" fill="#94a3b8" font-size="11" font-weight="600" letter-spacing="1">ADK MELODY AGENT</text>
+
+  <!-- Melody Agent model box -->
+  <rect x="546" y="102" width="168" height="76" rx="5" fill="#0f172a" stroke="#7c3aed" stroke-width="1.5"/>
+  <text x="630" y="124" text-anchor="middle" fill="#c4b5fd" font-size="11" font-weight="600">melody (Agent)</text>
+  <text x="630" y="141" text-anchor="middle" fill="#64748b" font-size="10">gemini-2.5-flash-native</text>
+  <text x="630" y="156" text-anchor="middle" fill="#64748b" font-size="10">-audio-latest</text>
+
+  <!-- google_search tool -->
+  <rect x="546" y="198" width="168" height="50" rx="5" fill="#0f172a" stroke="#475569" stroke-width="1"/>
+  <text x="630" y="218" text-anchor="middle" fill="#cbd5e1" font-size="11">google_search</text>
+  <text x="630" y="234" text-anchor="middle" fill="#64748b" font-size="10">ADK built-in tool</text>
+
+  <!-- emit_job_card tool -->
+  <rect x="546" y="268" width="168" height="50" rx="5" fill="#0f172a" stroke="#475569" stroke-width="1"/>
+  <text x="630" y="288" text-anchor="middle" fill="#cbd5e1" font-size="11">emit_job_card</text>
+  <text x="630" y="304" text-anchor="middle" fill="#64748b" font-size="10">writes → pending_cards</text>
+
+  <!-- ContextWindowCompression note -->
+  <rect x="546" y="338" width="168" height="40" rx="5" fill="#0f172a" stroke="#334155" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="630" y="356" text-anchor="middle" fill="#64748b" font-size="10">ContextWindowCompression</text>
+  <text x="630" y="371" text-anchor="middle" fill="#64748b" font-size="10">trigger=25k / target=20k tokens</text>
+
+  <!-- ───────────────────────────────────────────────────────────
+       EXTERNAL SERVICES box
+  ──────────────────────────────────────────────────────────── -->
+  <rect x="530" y="420" width="200" height="130" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1.5"/>
+  <text x="630" y="442" text-anchor="middle" fill="#94a3b8" font-size="11" font-weight="600" letter-spacing="1">EXTERNAL</text>
+
+  <!-- resume_parser -->
+  <rect x="546" y="452" width="168" height="40" rx="5" fill="#0f172a" stroke="#475569" stroke-width="1"/>
+  <text x="630" y="470" text-anchor="middle" fill="#cbd5e1" font-size="11">resume_parser</text>
+  <text x="630" y="485" text-anchor="middle" fill="#64748b" font-size="10">gemini-2.5-flash (Gemini API)</text>
+
+  <!-- Google Search API -->
+  <rect x="546" y="502" width="168" height="38" rx="5" fill="#0f172a" stroke="#475569" stroke-width="1"/>
+  <text x="630" y="521" text-anchor="middle" fill="#cbd5e1" font-size="11">Google Search API</text>
+  <text x="630" y="536" text-anchor="middle" fill="#64748b" font-size="10">via ADK google_search</text>
+
+  <!-- ═══════════════════════════════════════════════════════════
+       ARROWS
+  ═════════════════════════════════════════════════════════════-->
+
+  <!-- Browser Resume Upload → POST /upload -->
+  <line x1="210" y1="127" x2="283" y2="127" stroke="#f59e0b" stroke-width="1.5" marker-end="url(#arr-amber)"/>
+  <text x="246" y="119" text-anchor="middle" fill="#f59e0b" font-size="9">POST /upload</text>
+
+  <!-- POST /upload → resume_parser -->
+  <line x1="454" y1="135" x2="526" y2="472" stroke="#6366f1" stroke-width="1.5" marker-end="url(#arr-indigo)" stroke-dasharray="5,3"/>
+  <text x="510" y="420" text-anchor="end" fill="#6366f1" font-size="9">parse()</text>
+
+  <!-- POST /upload → Session Store (internal) -->
+  <line x1="370" y1="170" x2="370" y2="281" stroke="#475569" stroke-width="1" marker-end="url(#arr-gray)"/>
+  <text x="380" y="230" fill="#64748b" font-size="9">store</text>
+
+  <!-- Browser Audio Worklet → WebSocket (PCM 16kHz in) -->
+  <line x1="210" y1="200" x2="283" y2="220" stroke="#10b981" stroke-width="1.5" marker-end="url(#arr-green)"/>
+  <text x="246" y="198" text-anchor="middle" fill="#10b981" font-size="9">PCM 16 kHz in</text>
+
+  <!-- WebSocket → Browser Audio Player (PCM 24kHz out) -->
+  <line x1="283" y1="255" x2="210" y2="268" stroke="#38bdf8" stroke-width="1.5" marker-end="url(#arr-blue)"/>
+  <text x="246" y="250" text-anchor="middle" fill="#38bdf8" font-size="9">PCM 24 kHz out</text>
+
+  <!-- WebSocket → Job Card Renderer -->
+  <line x1="283" y1="270" x2="210" y2="346" stroke="#f472b6" stroke-width="1.5" marker-end="url(#arr-pink)"/>
+  <text x="235" y="315" fill="#f472b6" font-size="9">job_card JSON</text>
+
+  <!-- WebSocket → InMemoryRunner -->
+  <line x1="370" y1="264" x2="370" y2="351" stroke="#475569" stroke-width="1" marker-end="url(#arr-gray)"/>
+  <text x="380" y="312" fill="#64748b" font-size="9">queue</text>
+
+  <!-- InMemoryRunner → Melody Agent -->
+  <line x1="456" y1="387" x2="527" y2="150" stroke="#7c3aed" stroke-width="1.5" marker-end="url(#arr-purple)"/>
+  <text x="500" y="295" text-anchor="middle" fill="#7c3aed" font-size="9">run_live()</text>
+
+  <!-- Melody Agent → google_search (internal, vertical) -->
+  <line x1="630" y1="178" x2="630" y2="195" stroke="#475569" stroke-width="1" marker-end="url(#arr-gray)"/>
+
+  <!-- google_search → Google Search API -->
+  <line x1="714" y1="223" x2="760" y2="502" stroke="#475569" stroke-width="1" marker-end="url(#arr-gray)" stroke-dasharray="4,3"/>
+
+  <!-- Melody Agent → emit_job_card (internal, vertical) -->
+  <line x1="630" y1="248" x2="630" y2="265" stroke="#475569" stroke-width="1" marker-end="url(#arr-gray)"/>
+
+  <!-- emit_job_card → pending_cards → WebSocket flush (back arrow) -->
+  <path d="M546,293 Q490,293 490,370 Q490,440 456,440 Q420,440 420,387" fill="none" stroke="#f472b6" stroke-width="1.5" marker-end="url(#arr-pink)" stroke-dasharray="4,3"/>
+  <text x="475" y="460" text-anchor="middle" fill="#f472b6" font-size="9">pending_cards flush</text>
+
+  <!-- ───────────────────────────────────────────────────────────
+       Arrow marker definitions
+  ──────────────────────────────────────────────────────────── -->
+  <defs>
+    <marker id="arr-amber" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#f59e0b"/>
+    </marker>
+    <marker id="arr-green" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#10b981"/>
+    </marker>
+    <marker id="arr-blue" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#38bdf8"/>
+    </marker>
+    <marker id="arr-pink" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#f472b6"/>
+    </marker>
+    <marker id="arr-purple" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#7c3aed"/>
+    </marker>
+    <marker id="arr-indigo" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#6366f1"/>
+    </marker>
+    <marker id="arr-gray" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#475569"/>
+    </marker>
+  </defs>
+
+  <!-- ───────────────────────────────────────────────────────────
+       Legend
+  ──────────────────────────────────────────────────────────── -->
+  <rect x="30" y="574" width="840" height="36" rx="5" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+  <text x="50" y="588" fill="#94a3b8" font-size="10" font-weight="600">Legend:</text>
+  <line x1="110" y1="585" x2="138" y2="585" stroke="#f59e0b" stroke-width="1.5" marker-end="url(#arr-amber)"/>
+  <text x="142" y="589" fill="#f59e0b" font-size="10">HTTP upload</text>
+  <line x1="215" y1="585" x2="243" y2="585" stroke="#10b981" stroke-width="1.5" marker-end="url(#arr-green)"/>
+  <text x="247" y="589" fill="#10b981" font-size="10">PCM audio in 16 kHz</text>
+  <line x1="360" y1="585" x2="388" y2="585" stroke="#38bdf8" stroke-width="1.5" marker-end="url(#arr-blue)"/>
+  <text x="392" y="589" fill="#38bdf8" font-size="10">PCM audio out 24 kHz</text>
+  <line x1="510" y1="585" x2="538" y2="585" stroke="#f472b6" stroke-width="1.5" marker-end="url(#arr-pink)"/>
+  <text x="542" y="589" fill="#f472b6" font-size="10">job card JSON</text>
+  <line x1="630" y1="585" x2="658" y2="585" stroke="#7c3aed" stroke-width="1.5" marker-end="url(#arr-purple)"/>
+  <text x="662" y="589" fill="#7c3aed" font-size="10">ADK run_live()</text>
+  <line x1="760" y1="585" x2="788" y2="585" stroke="#475569" stroke-width="1.5" marker-end="url(#arr-gray)"/>
+  <text x="792" y="589" fill="#64748b" font-size="10">internal</text>
+
+  <!-- second legend row for audio labels inside legend -->
+  <text x="247" y="601" fill="#64748b" font-size="9">(base64 JSON envelope)</text>
+  <text x="392" y="601" fill="#64748b" font-size="9">(base64 JSON envelope)</text>
+
+</svg>


### PR DESCRIPTION
## Summary
- Creates `assets/architecture.svg` with a dark-themed diagram showing the full Melody system architecture
- Covers all required components from issue #22: upload flow, WebSocket audio path, ADK runner, tools, job card flush, and static file serving
- Audio PCM paths are labeled (16 kHz in / 24 kHz out) with base64 JSON envelope notes

## Diagram elements
| Component | Shown |
|---|---|
| Browser → POST /upload → resume_parser (gemini-2.5-flash) → session store | ✅ |
| Browser ↔ WebSocket → FastAPI → InMemoryRunner → Melody (gemini-2.5-flash-native-audio-latest) | ✅ |
| Melody → google_search → Google Search API | ✅ |
| Melody → emit_job_card → pending_cards → WebSocket → browser | ✅ |
| PCM 16 kHz in / 24 kHz out labels | ✅ |
| StaticFiles: client/ → FastAPI → browser | ✅ |

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)