### PR TITLE
fix: commit server/melody_agent/__init__.py (issue #92)

### DIFF
--- a/server/melody_agent/__init__.py
+++ b/server/melody_agent/__init__.py
@@ -1,0 +1,1 @@
+from . import agent


### PR DESCRIPTION
## Summary
- Commits the previously untracked `server/melody_agent/__init__.py` file
- Without it, Python cannot treat `melody_agent` as a package, causing `ModuleNotFoundError` on Cloud Run startup

## Test plan
- [ ] Verify `git ls-files server/melody_agent/__init__.py` shows the file is tracked
- [ ] Confirm a fresh clone builds and starts without `ModuleNotFoundError`

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)