### PR TITLE
fix: track search_ran flag to guard emit_job_card ordering (issue #96)

### DIFF
--- a/server/melody_agent/agent.py
+++ b/server/melody_agent/agent.py
@@ -31,6 +31,7 @@ def _after_tool(tool, args, tool_context, tool_response):
     print(f"[tool] {tool.name} END   | elapsed={elapsed:.1f}s", flush=True)
 
     if tool.name == "google_search" and isinstance(tool_response, str):
+        tool_context.state["search_ran"] = True
         if len(tool_response) > _SEARCH_RESULT_CHAR_LIMIT:
             print(
                 f"[tool] google_search truncating response "

--- a/server/melody_agent/tools.py
+++ b/server/melody_agent/tools.py
@@ -3,6 +3,7 @@
 from google.adk.tools import ToolContext
 
 
+
 def build_job_query(tool_context: ToolContext, state: dict) -> dict:
     """Build a Google search query for job postings from conversation state.
 
@@ -53,6 +54,21 @@ def emit_job_card(
     Appends a card dict to tool_context.state['pending_cards'] so the
     WebSocket handler can forward it to the browser as a JSON event.
     """
+    if not tool_context.state.get("search_ran"):
+        return {
+            "error": (
+                "You must call google_search before emit_job_card. "
+                "No search has been run in this session yet."
+            )
+        }
+
+    if not url.startswith("http") or "example.com" in url:
+        return {
+            "error": (
+                f"'{url}' is not a real job posting URL. Use only URLs from the google_search results."
+            )
+        }
+
     card = {
         "title": title,
         "company": company,


### PR DESCRIPTION
## Summary
- Sets `tool_context.state["search_ran"] = True` in `_after_tool` when `google_search` completes
- Guards `emit_job_card` with an early-return error if `search_ran` is not set, preventing fabricated job cards before any real search data exists
- Also rejects placeholder/example URLs at the tool level

Closes #96

## Test plan
- [ ] Start a session and call `emit_job_card` before `google_search` — should return `{"error": "You must call google_search before emit_job_card..."}`
- [ ] Run `google_search`, then call `emit_job_card` — should succeed and append to `pending_cards`
- [ ] Call `emit_job_card` with an `example.com` URL — should return the URL validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)