### PR TITLE
fix: pin model to stable GA ID gemini-live-2.5-flash-native-audio (issue #94)

### DIFF
--- a/server/melody_agent/agent.py
+++ b/server/melody_agent/agent.py
@@ -51,7 +51,7 @@ def create_agent(resume_data: dict) -> Agent:
     """
     return Agent(
         name="melody",
-        model="gemini-2.5-flash-native-audio-latest",
+        model="gemini-live-2.5-flash-native-audio",
         instruction=build_prompt(resume_data),
         tools=[google_search, emit_job_card],
         before_tool_callback=_before_tool,


### PR DESCRIPTION
## Summary
- Replaces `gemini-2.5-flash-native-audio-latest` with the stable GA model ID `gemini-live-2.5-flash-native-audio`
- Fixes the `-latest` alias instability that caused the submission-day 1008 crash (model changed silently overnight)
- Also corrects the naming inconsistency (`gemini-2.5-flash-native-audio-*` → `gemini-live-2.5-flash-native-audio` with `live` as a segment)

Closes #94

## Test plan
- [ ] Run `adk web` locally and verify voice session connects successfully with new model string
- [ ] Confirm no 1008 errors on session start

🤖 Generated with [Claude Code](https://claude.com/claude-code)