### PR TITLE
fix: use gemini-2.5-flash-native-audio-latest to match ClearRight (issue #101)

### DIFF
--- a/server/melody_agent/agent.py
+++ b/server/melody_agent/agent.py
@@ -51,7 +51,7 @@ def create_agent(resume_data: dict) -> Agent:
     """
     return Agent(
         name="melody",
-        model="gemini-2.5-flash-native-audio-preview-12-2025",
+        model="gemini-2.5-flash-native-audio-latest",
         instruction=build_prompt(resume_data),
         tools=[google_search, emit_job_card],
         before_tool_callback=_before_tool,


### PR DESCRIPTION
## Summary
- Keeps model as `gemini-2.5-flash-native-audio-latest` — the same alias used by ClearRight ([engr-krooozy/clearright](https://github.com/engr-krooozy/clearright)), a confirmed working ADK voice app
- `gemini-live-2.5-flash-native-audio` (PR #99) uses Vertex AI naming and is rejected by Gemini API v1alpha with 1008 "not found for bidiGenerateContent"
- The `-latest` alias is confirmed stable by ClearRight; a pinned GA string will be substituted once one is verified to work with bidiGenerateContent

## Test plan
- [ ] Start server locally with `./run_local.sh`
- [ ] Connect a voice session — confirm no 1008 error at connection time
- [ ] Speak to Melody and trigger `google_search` — confirm session stays alive

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)