### PR TITLE
fix: reconnect on 1011 using SessionResumptionConfig (issue #102)

### DIFF
--- a/.claude/scratchpads/issue-102-session-resumption-1011.md
+++ b/.claude/scratchpads/issue-102-session-resumption-1011.md
@@ -1,0 +1,54 @@
+# Issue #102 — bug: session drops mid-delivery with 1011 Internal error
+
+https://github.com/rawleez/melody/issues/102
+
+## Problem
+
+Voice sessions terminate mid-response with a 1011 WebSocket close from Google's servers.
+The session is unrecoverable — no retry/reconnect logic exists, user must start over.
+
+## Root cause
+
+1011 is a Google-side transient error. No retry logic exists in `send_events()`.
+
+## Fix plan
+
+### What to implement
+
+1. Enable `SessionResumptionConfig(transparent=True)` in `RunConfig` so Google sends
+   `live_session_resumption_update` events with a `new_handle` whenever the session
+   is in a resumable state.
+
+2. In `send_events`, track the latest resumable handle from
+   `event.live_session_resumption_update.new_handle`.
+
+3. Wrap `runner.run_live(...)` in a retry loop (max 3 retries, exponential backoff:
+   1s → 2s → 4s) that catches 1011 `google.genai.errors.APIError`.
+
+4. On 1011:
+   - Close the old `LiveRequestQueue`
+   - Create a new one (stored in a mutable shared ref so `receive_audio` picks it up)
+   - Rebuild `RunConfig` with `SessionResumptionConfig(handle=last_good_handle)` if available
+   - Retry `run_live` with the new queue
+
+5. `receive_audio` reads from `queue_ref[0]` (mutable list) instead of a fixed queue
+   reference, so it automatically routes audio to the current queue after reconnect.
+
+### Key ADK types used
+
+- `RunConfig.session_resumption: SessionResumptionConfig`
+- `SessionResumptionConfig(handle=None, transparent=True)` — first connection
+- `SessionResumptionConfig(handle=saved_handle, transparent=True)` — reconnect
+- `Event.live_session_resumption_update: LiveServerSessionResumptionUpdate`
+  - `.resumable: bool` — True if session can be resumed right now
+  - `.new_handle: str` — opaque token to use on reconnect
+
+### Files changed
+
+- `server/main.py` — reconnect loop in `websocket_session`
+
+### What we do NOT change
+
+- The initial greeting `send_content("Hello")` is only sent on first connect,
+  not on reconnect (conversation state is restored via the handle).
+- `agent.py` is unchanged.

--- a/server/main.py
+++ b/server/main.py
@@ -48,6 +48,10 @@ async def upload_resume(file: UploadFile = File(...)):
     return {"session_id": session_id, **parsed}
 
 
+_MAX_RECONNECTS = 3
+_RECONNECT_BACKOFF_BASE = 1.0  # seconds; doubles each retry
+
+
 @app.websocket("/ws/{session_id}")
 async def websocket_session(websocket: WebSocket, session_id: str):
     """Live voice session for a given resume session.
@@ -55,6 +59,9 @@ async def websocket_session(websocket: WebSocket, session_id: str):
     Binary frames in:  PCM 16-bit mono 16 kHz (from browser audio worklet)
     Binary frames out: PCM 16-bit mono 24 kHz (Gemini Live audio)
     Text frames out:   JSON {"type": "job_card", ...} after each agent turn
+
+    Reconnect on 1011 (Google transient internal error): up to _MAX_RECONNECTS
+    attempts using SessionResumptionConfig to restore conversation state.
     """
     resume_data = _sessions.get(session_id)
     if resume_data is None:
@@ -72,14 +79,12 @@ async def websocket_session(websocket: WebSocket, session_id: str):
     )
     adk_session_id = adk_session.id
 
-    live_queue = LiveRequestQueue()
-    run_config = RunConfig(
-        streaming_mode=StreamingMode.BIDI,
-        context_window_compression=genai_types.ContextWindowCompressionConfig(
-            sliding_window=genai_types.SlidingWindow(target_tokens=20000),
-            trigger_tokens=25000,
-        ),
-    )
+    # Mutable ref so receive_audio always routes to the current queue,
+    # even after a reconnect swaps it out.
+    queue_ref: list[LiveRequestQueue] = [LiveRequestQueue()]
+
+    # Latest resumable session handle from Google (updated as events arrive).
+    resumption_handle: list[str | None] = [None]
 
     async def receive_audio():
         """Browser → LiveRequestQueue: decode base64 JSON envelope and forward PCM."""
@@ -91,61 +96,102 @@ async def websocket_session(websocket: WebSocket, session_id: str):
                     pcm_data = base64.b64decode(msg["data"])
                 except (json.JSONDecodeError, KeyError, Exception):
                     continue  # drop malformed frames
-                live_queue.send_realtime(
+                queue_ref[0].send_realtime(
                     genai_types.Blob(data=pcm_data, mime_type="audio/pcm;rate=16000")
                 )
         except WebSocketDisconnect:
-            live_queue.close()
+            queue_ref[0].close()
 
     async def send_events():
-        """ADK events → browser: base64 JSON audio envelope and job cards."""
-        try:
-            async for event in runner.run_live(
-                user_id="user",
-                session_id=adk_session_id,
-                live_request_queue=live_queue,
-                run_config=run_config,
-            ):
-                # Collect audio parts and send as a single JSON envelope
-                audio_parts = []
-                if event.content and event.content.parts:
-                    for part in event.content.parts:
-                        if part.inline_data and part.inline_data.data:
-                            audio_parts.append({
-                                "type": "audio/pcm",
-                                "data": base64.b64encode(part.inline_data.data).decode("ascii"),
-                            })
+        """ADK events → browser: base64 JSON audio envelope and job cards.
 
-                if audio_parts or event.turn_complete or getattr(event, "interrupted", False):
-                    envelope: dict = {
-                        "parts": audio_parts,
-                        "turn_complete": bool(event.turn_complete),
-                        "interrupted": bool(getattr(event, "interrupted", False)),
-                    }
-                    await websocket.send_text(json.dumps(envelope))
+        Retries up to _MAX_RECONNECTS times on 1011 transient Google errors,
+        using the last known resumption handle to restore conversation state.
+        """
+        retry = 0
+        while True:
+            run_config = RunConfig(
+                streaming_mode=StreamingMode.BIDI,
+                session_resumption=genai_types.SessionResumptionConfig(
+                    handle=resumption_handle[0],
+                    transparent=True,
+                ),
+                context_window_compression=genai_types.ContextWindowCompressionConfig(
+                    sliding_window=genai_types.SlidingWindow(target_tokens=20000),
+                    trigger_tokens=25000,
+                ),
+            )
+            try:
+                async for event in runner.run_live(
+                    user_id="user",
+                    session_id=adk_session_id,
+                    live_request_queue=queue_ref[0],
+                    run_config=run_config,
+                ):
+                    # Track the latest resumable handle for reconnect.
+                    upd = event.live_session_resumption_update
+                    if upd and upd.resumable and upd.new_handle:
+                        resumption_handle[0] = upd.new_handle
 
-                # After each turn flush pending job cards from session state
-                if event.turn_complete:
-                    try:
-                        real_session = runner.session_service.sessions[
-                            runner.app_name
-                        ]["user"][adk_session_id]
-                        cards = real_session.state.pop("pending_cards", [])
-                        for card in cards:
-                            await websocket.send_text(
-                                json.dumps({"type": "job_card", **card})
-                            )
-                    except (KeyError, AttributeError):
-                        pass  # state not yet populated or structure differs
-        except WebSocketDisconnect:
-            pass
-        except Exception as exc:
-            print(f"[send_events] error: {exc}", flush=True)
-            raise
+                    # Collect audio parts and send as a single JSON envelope.
+                    audio_parts = []
+                    if event.content and event.content.parts:
+                        for part in event.content.parts:
+                            if part.inline_data and part.inline_data.data:
+                                audio_parts.append({
+                                    "type": "audio/pcm",
+                                    "data": base64.b64encode(part.inline_data.data).decode("ascii"),
+                                })
+
+                    if audio_parts or event.turn_complete or getattr(event, "interrupted", False):
+                        envelope: dict = {
+                            "parts": audio_parts,
+                            "turn_complete": bool(event.turn_complete),
+                            "interrupted": bool(getattr(event, "interrupted", False)),
+                        }
+                        await websocket.send_text(json.dumps(envelope))
+
+                    # After each turn flush pending job cards from session state.
+                    if event.turn_complete:
+                        try:
+                            real_session = runner.session_service.sessions[
+                                runner.app_name
+                            ]["user"][adk_session_id]
+                            cards = real_session.state.pop("pending_cards", [])
+                            for card in cards:
+                                await websocket.send_text(
+                                    json.dumps({"type": "job_card", **card})
+                                )
+                        except (KeyError, AttributeError):
+                            pass  # state not yet populated or structure differs
+
+                # run_live exhausted normally — session complete.
+                break
+
+            except WebSocketDisconnect:
+                break
+            except Exception as exc:
+                err = str(exc)
+                if "1011" in err and retry < _MAX_RECONNECTS:
+                    retry += 1
+                    backoff = _RECONNECT_BACKOFF_BASE * (2 ** (retry - 1))
+                    print(
+                        f"[send_events] 1011 error — reconnect attempt {retry}/{_MAX_RECONNECTS} "
+                        f"in {backoff:.0f}s (handle={'set' if resumption_handle[0] else 'none'})",
+                        flush=True,
+                    )
+                    await asyncio.sleep(backoff)
+                    # Swap to a fresh queue; receive_audio picks it up via queue_ref.
+                    queue_ref[0].close()
+                    queue_ref[0] = LiveRequestQueue()
+                else:
+                    print(f"[send_events] error: {exc}", flush=True)
+                    raise
 
     # Kick off Melody's opening greeting — without this, BIDI mode waits
     # for the user to speak first and the session appears stalled.
-    live_queue.send_content(
+    # Only sent on first connect; reconnects restore state via resumption handle.
+    queue_ref[0].send_content(
         content=genai_types.Content(
             role="user",
             parts=[genai_types.Part(text="Hello")],


### PR DESCRIPTION
## Summary

- Enables `SessionResumptionConfig(transparent=True)` on every live session so Google streams resumable handles throughout the conversation
- Tracks the latest `new_handle` from `event.live_session_resumption_update` during the event loop
- On `1011` error: closes the old `LiveRequestQueue`, creates a fresh one (shared via mutable `queue_ref` so `receive_audio` routes to it automatically), then retries `run_live` with the saved handle — up to 3 attempts with 1s/2s/4s exponential backoff
- `receive_audio` now reads from `queue_ref[0]` instead of a captured-at-closure queue, enabling transparent swap on reconnect

Closes #102.

## Test plan

- [ ] Run `./run_local.sh`, start a session, verify normal flow works (no regression)
- [ ] Check logs for `live_session_resumption_update` events with `resumable=True` and non-empty `new_handle` — confirms Google is sending handles
- [ ] Simulate 1011: if a 1011 occurs in staging, confirm logs show `[send_events] 1011 error — reconnect attempt 1/3` and session resumes rather than hard-dropping
- [ ] Deploy with `./deploy.sh` and verify Cloud Run logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)