### PR TITLE
fix: deduplicate emit_job_card calls per session (issue #100)

### DIFF
--- a/.claude/scratchpads/issue-100-emit-job-card-dedupe.md
+++ b/.claude/scratchpads/issue-100-emit-job-card-dedupe.md
@@ -1,0 +1,28 @@
+# Issue #100: emit_job_card fires duplicate calls in same session
+
+**Issue:** https://github.com/rawleez/melody/issues/100
+**Branch:** fix/100-emit-job-card-dedupe
+
+## Problem
+
+`emit_job_card` is being called twice for the same jobs within a single session. The `search_ran` guard (from #96) prevents duplicate searches but does not prevent the model from re-calling `emit_job_card` for already-presented jobs.
+
+## Root Cause
+
+`tools.py` `emit_job_card` — no deduplication guard on emitted job URLs. The model can loop back and re-present jobs it already called `emit_job_card` for.
+
+## Plan
+
+### Step 1 — Add URL deduplication guard in `tools.py`
+- On each `emit_job_card` call, check `tool_context.state.get("emitted_urls", [])`
+- If the URL is already in the list, return an error/skip response
+- Otherwise, append the URL to the list before emitting
+
+### Step 2 — Strengthen system prompt in `prompts.py`
+- Add explicit instruction: do NOT re-call `emit_job_card` for jobs already presented
+- Reference the fact that the tool will reject duplicates
+
+## Changes
+
+- `server/melody_agent/tools.py` — add `emitted_urls` guard
+- `server/melody_agent/prompts.py` — strengthen delivery phase instructions

--- a/server/melody_agent/prompts.py
+++ b/server/melody_agent/prompts.py
@@ -66,7 +66,10 @@ or more of a nice-to-have?"
 - Every job you present MUST come from the `google_search` results. Use the real company \
 names, job titles, and URLs from the search. Never invent a company, title, or URL. \
 Never use example.com or placeholder URLs.
-- For each job, call `emit_job_card` as you speak it aloud.
+- Call `emit_job_card` for ALL 3 jobs first (before speaking any of them aloud), \
+then speak all results aloud. Never interleave tool calls with audio output.
+- Call `emit_job_card` **exactly once per job**. Never call it a second time for a \
+URL you have already emitted — the tool will reject the duplicate.
 - When presenting each job, explicitly reference something the user actually said in this \
 conversation to explain the fit. Do not present jobs as abstract matches — connect each \
 one to a specific priority or concern they voiced.

--- a/server/melody_agent/tools.py
+++ b/server/melody_agent/tools.py
@@ -69,6 +69,15 @@ def emit_job_card(
             )
         }
 
+    emitted_urls = tool_context.state.get("emitted_urls", [])
+    if url in emitted_urls:
+        return {
+            "error": (
+                f"Job card for '{url}' has already been emitted this session. "
+                "Do not call emit_job_card twice for the same job."
+            )
+        }
+
     card = {
         "title": title,
         "company": company,
@@ -80,5 +89,7 @@ def emit_job_card(
     if "pending_cards" not in tool_context.state:
         tool_context.state["pending_cards"] = []
     tool_context.state["pending_cards"].append(card)
+
+    tool_context.state["emitted_urls"] = emitted_urls + [url]
 
     return {"status": "emitted", "card": card}


### PR DESCRIPTION
## Summary
- Adds `emitted_urls` tracking to `ToolContext.state` in `emit_job_card`; returns an error and skips emission if the URL was already emitted this session
- Updates the delivery phase system prompt to emit all 3 cards before speaking (prevents audio/tool-call interleaving) and explicitly forbids re-calling `emit_job_card` for already-presented jobs

## Test plan
- [ ] Start a session, trigger the delivery phase — verify 3 cards emitted once each
- [ ] Confirm no duplicate cards appear in the UI even if the model loops
- [ ] Confirm the error response (`"already been emitted"`) is returned if the model retries a URL

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)